### PR TITLE
qemux86: Confirmed layer is SERIES_COMPAT with hardknott

### DIFF
--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
 LAYERDEPENDS_meta-rauc-qemux86 = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemux86 = "honister"
+LAYERSERIES_COMPAT_meta-rauc-qemux86 = "honister hardknott"


### PR DESCRIPTION
I have verified the "meta-rauc-qemux86" layer works with with the poky "hardknott" branch.