### PR TITLE
Update meta-rauc-qemux86 for 'kirkstone'

### DIFF
--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
 LAYERDEPENDS_meta-rauc-qemux86 = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemux86 = "honister hardknott"
+LAYERSERIES_COMPAT_meta-rauc-qemux86 = "honister hardknott kirkstone"

--- a/meta-rauc-qemux86/recipes-bsp/boot-image/boot-image.bb
+++ b/meta-rauc-qemux86/recipes-bsp/boot-image/boot-image.bb
@@ -52,6 +52,6 @@ do_deploy () {
     mv ${GRUBENV_IMG} ${DEPLOYDIR}/
 }
 
-do_deploy[cleandirs] = "${WORKDIR}/efi-boot"
+do_deploy[cleandirs] += "${WORKDIR}/efi-boot"
 
 addtask deploy after do_install


### PR DESCRIPTION
* Add 'kirkstone' to `LAYERSERIES_COMPAT`
* Fix [cleandirs] handling for boot-image recipe

Fixes #31 