### PR TITLE
Prepare meta-rauc-qemux86 for RAUC Adaptive Updates

### DIFF
--- a/meta-rauc-qemux86/README.rst
+++ b/meta-rauc-qemux86/README.rst
@@ -26,6 +26,7 @@ Features
 * Atomic EFI bootloader (GRUB) updates
 * Shared data partition (with RAUC central slot status)
 * Example bundle recipe
+* Ready for testing RAUC adaptive updates
 
 I. Adding the meta-rauc-qemux86 layer to your build
 ===================================================

--- a/meta-rauc-qemux86/recipes-core/bundles/qemu-demo-bundle.bb
+++ b/meta-rauc-qemux86/recipes-core/bundles/qemu-demo-bundle.bb
@@ -12,6 +12,9 @@ RAUC_BUNDLE_SLOTS = "efi rootfs"
 RAUC_IMAGE_FSTYPE = "tar.bz2"
 
 RAUC_SLOT_rootfs = "core-image-minimal"
+# uncomment for enabling adaptive update method 'block-hash-index'
+#RAUC_SLOT_rootfs[fstype] = "ext4"
+#RAUC_SLOT_rootfs[adaptive] = "block-hash-index"
 
 RAUC_SLOT_efi = "boot-image"
 RAUC_SLOT_efi[file] = "efi-boot.vfat"

--- a/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend
@@ -1,6 +1,6 @@
 IMAGE_INSTALL:append = " kernel-image kernel-modules"
 
-IMAGE_FSTYPES += "wic"
+IMAGE_FSTYPES += "wic ext4"
 WKS_FILE = "qemux86-grub-efi.wks"
 do_image_wic[depends] += "boot-image:do_deploy"
 

--- a/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend
@@ -3,3 +3,9 @@ IMAGE_INSTALL:append = " kernel-image kernel-modules"
 IMAGE_FSTYPES += "wic"
 WKS_FILE = "qemux86-grub-efi.wks"
 do_image_wic[depends] += "boot-image:do_deploy"
+
+# Optimizations for RAUC adaptive method 'block-hash-index'
+# rootfs image size must to be 4K-aligned
+IMAGE_ROOTFS_ALIGNMENT = "4"
+# ext4 block and inode size should be set to 4K
+EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"

--- a/meta-rauc-qemux86/recipes-core/rauc/files/qemux86-64/system.conf
+++ b/meta-rauc-qemux86/recipes-core/rauc/files/qemux86-64/system.conf
@@ -2,7 +2,7 @@
 compatible=qemu86-64 demo platform
 bootloader=grub
 grubenv=/grubenv/grubenv
-statusfile=/data/rauc.status
+data-directory=/data/
 
 [keyring]
 path=ca.cert.pem

--- a/meta-rauc-qemux86/wic/qemux86-grub-efi.wks
+++ b/meta-rauc-qemux86/wic/qemux86-grub-efi.wks
@@ -12,6 +12,6 @@ part --fixed-size 50M --source rawcopy --sourceparams="file=efi-boot.vfat" --fst
 part --fixed-size 50M --ondisk sda --align 4096 --no-table
 part --fixed-size 10M --source rawcopy --sourceparams="file=grubenv.vfat" --fstype=vfat --ondisk sda --label grubenv --align 1024
 part /rescue --source rootfs --ondisk sda --fstype=ext4 --label rescue --align 1024
-part / --source rootfs --ondisk sda --fstype=ext4 --label root_a --align 4096
-part / --source rootfs --ondisk sda --fstype=ext4 --label root_b --align 4096
+part / --source rootfs --ondisk sda --fstype=ext4 --label root_a --fixed-size=150M --align 4096
+part / --source rootfs --ondisk sda --fstype=ext4 --label root_b --fixed-size=150M --align 4096
 part /data --fixed-size 100M --ondisk sda --fstype=ext4 --label data --align 4096


### PR DESCRIPTION
This adds configuration required to test RAUC's 1.8 [adaptive update](https://rauc.readthedocs.io/en/latest/advanced.html#adaptive-updates) feature on qemux86-64.

To enable it, just uncomment the two lines in the `qemu-demo-bundle.bb` file and upload it to a web server you have access to from your qemu.