### PR TITLE
meta-rauc-raspberrypi/README.rst: Use :append

### DIFF
--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -58,7 +58,7 @@ Add configuration required for meta-rauc-raspberrypi to your local.conf::
 
    # Settings for meta-rauc-raspberry-pi
    IMAGE_INSTALL:append = " rauc"
-   IMAGE_FSTYPES += "ext4"
+   IMAGE_FSTYPES:append = " ext4"
    WKS_FILE = "sdimage-dual-raspberrypi.wks.in"
 
 Make sure either your distro (recommended) or your local.conf have ``rauc``


### PR DESCRIPTION
Use `:append` instead of `+=` for `IMAGE_FSTYPES` to avoid ordering issues of the variable which is set to a default value using the `?=` operator in `rpi-base.inc` from layer `meta-raspberrypi`. The patch should be applied to the main and kirkstone branches.

Best regards,
Leon