### PR TITLE
meta-rauc-raspberrypi: Add data directory

### DIFF
--- a/meta-rauc-raspberrypi/recipes-core/rauc/files/system.conf
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/files/system.conf
@@ -1,6 +1,7 @@
 [system]
 compatible=RaspberryPi4
 bootloader=uboot
+data-directory=/data/
 
 [keyring]
 path=/etc/rauc/ca.cert.pem

--- a/meta-rauc-raspberrypi/wic/sdimage-dual-raspberrypi.wks.in
+++ b/meta-rauc-raspberrypi/wic/sdimage-dual-raspberrypi.wks.in
@@ -1,4 +1,5 @@
 part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 100
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_A --align 4096
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_B --align 4096
+part /data --fixed-size 100M --ondisk mmcblk0 --fstype=ext4 --label data --align 4096
 part /home --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/home --ondisk mmcblk0 --fstype=ext4 --label homefs --align 1024 --size 500 --fsoptions "x-systemd.growfs"


### PR DESCRIPTION
Add a data directory with a fixed size of 100MB for Raspberry Pi and configure data-directory to /data/ in RAUC's system.conf.

This makes use of the new 'data-directory' introduced by RAUC version 1.8 which will be used for adaptive updates and other new features in future.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>