### PR TITLE
meta-rauc-raspberrypi: base-files_%.bbappend: Adding /home to fstab

### DIFF
--- a/meta-rauc-raspberrypi/recipes-core/base-files/files/fstab
+++ b/meta-rauc-raspberrypi/recipes-core/base-files/files/fstab
@@ -9,4 +9,5 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 # uncomment this if your device has a SD/MMC/Transflash slot
 #/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
 
-/dev/mmcblk0p1  /boot   vfat    defaults        0       0
+/dev/mmcblk0p1  /boot   vfat    defaults         0       0
+/dev/mmcblk0p4  /home   ext4    x-systemd.growfs 0       0


### PR DESCRIPTION
Ensuring that /home will be automatically mounted when booting into the upgraded root partition.

Provides solution to: https://github.com/rauc/meta-rauc-community/issues/15
