### PR TITLE
meta-rauc-raspberrypi: base-files_%.bbappend: Adding /home and /data …

### DIFF
--- a/meta-rauc-raspberrypi/recipes-core/base-files/files/fstab
+++ b/meta-rauc-raspberrypi/recipes-core/base-files/files/fstab
@@ -9,4 +9,6 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 # uncomment this if your device has a SD/MMC/Transflash slot
 #/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
 
-/dev/mmcblk0p1  /boot   vfat    defaults        0       0
+/dev/mmcblk0p1  /boot   vfat    defaults         0       0
+/dev/mmcblk0p5  /data   ext4    defaults         0       0
+/dev/mmcblk0p6  /home   ext4    x-systemd.growfs 0       0


### PR DESCRIPTION
…to fstab

I'm doing a second pull request because the generated partitions are different in the kirkstone and the master branch.


Why when i build the image there appears an extra partition not mentioned in the wic file? /dev/mmcblk0p4 of type "Win95 Ext'd (LBA)"

