### PR TITLE
qemux86: README.rst: Add port forwarding note

### DIFF
--- a/meta-rauc-qemux86/README.rst
+++ b/meta-rauc-qemux86/README.rst
@@ -102,6 +102,18 @@ run::
 
   # rauc status
 
+Note:
+By default using ``slirp`` will forward ports 22 and 23 on the qemu system to ports 2222 and 2323 on the host system.
+If there is a collision with another runqemu instance, the script will pick the next free port.
+You can define custom port forwarding by setting ``hostfwd`` in ``QB_SLIRP_OPT``. Examples::
+
+    $ QB_SLIRP_OPT="-netdev user,id=net0,hostfwd=tcp::<host system port>-:<qemu system port>" runqemu core-image-minimal wic nographic ovmf slirp
+
+    $ QB_SLIRP_OPT="-netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2323-:23" runqemu core-image-minimal wic nographic ovmf slirp
+
+Slirp can be useful for remote access to the virtual machine without needing root access to the host machine.
+Keep in mind firewalls on both the host and the qemu machines should be configured based on your needs.
+
 IV. Build and Install The Demo Bundle
 =====================================
 


### PR DESCRIPTION
Added note explaining how to forward ports from the QEMU system to the host system when using Slirp.