### PR TITLE
meta-rauc-tegra: switch to using 'verity' bundle format

### DIFF
--- a/meta-rauc-tegra/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-tegra/recipes-core/bundles/update-bundle.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "RAUC bundle generator"
 
 inherit bundle
 
+RAUC_BUNDLE_FORMAT = "verity"
+
 RAUC_BUNDLE_COMPATIBLE = "jetson-tx2-devkit"
 RAUC_BUNDLE_VERSION = "v20211104"
 RAUC_BUNDLE_DESCRIPTION = "RAUC Demo Bundle"


### PR DESCRIPTION
The kernel configuration already enabled 'verity' support, but the bundle did not.

The 'verity' format is the successor of the legacy 'plain' format which is still supported by RAUC but should not be used for new projects.

Also note that only the 'verity' format allows using RAUC features as streaming, encryption and adaptive updates.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>