### PR TITLE
qemux86: layer.conf: remove compatiblity with 'honister' and 'hardknott'

### DIFF
--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
 LAYERDEPENDS_meta-rauc-qemux86 = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemux86 = "honister hardknott kirkstone"
+LAYERSERIES_COMPAT_meta-rauc-qemux86 = "kirkstone"


### PR DESCRIPTION
honister is EOL and since the version of meta-rauc-qemux86 requires RAUC 1.8 which is not part of meta-rauc's honister branch, compatibility is clearly broken.

Same applies to 'hardknott'.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>