### PR TITLE
raspberrypi: Add mickledore compatibility

### DIFF
--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-raspberrypi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-raspberrypi = "6"
 
 LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
-LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell gatesgarth hardknott honister kirkstone"
+LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell gatesgarth hardknott honister kirkstone mickledore"


### PR DESCRIPTION
Adds `mickledore` compatibility.

### Testing
- [x] Raspberry PI CM4 Lite boots.
- [x] A/B switching works.

![image](https://github.com/rauc/meta-rauc-community/assets/8194523/222774d2-36e8-4a94-9d47-e1a35ef6720f)
