### PR TITLE
Update base-files_%.bbappend

### DIFF
--- a/meta-rauc-raspberrypi/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/base-files/base-files_%.bbappend
@@ -1,1 +1,4 @@
 FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/files:"
+
+# Add a mount point for a shared data partition
+dirs755 += "/data"


### PR DESCRIPTION
The data partition from the core image fails mounting due to missing mount point. Solution copied from meta-rauc-qemux86.