### PR TITLE
Add Minimal Github Action Workflows For qemux86 and raspberrypi

### DIFF
--- a/.github/workflows/meta-rauc-qemux86.yml
+++ b/.github/workflows/meta-rauc-qemux86.yml
@@ -1,0 +1,47 @@
+name: meta-rauc-qemux86 CI
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+    paths:
+      - 'meta-rauc-qemux86/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'meta-rauc-qemux86/**'
+jobs:
+  build:
+    name: meta-rauc-qemux86 Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install required packages
+        run: |
+          sudo apt-get install diffstat
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clone poky
+        run: git clone -b master git://git.yoctoproject.org/poky
+      - name: Clone meta-rauc
+        run: git clone -b master https://github.com/rauc/meta-rauc.git
+      - name: Initialize build directory
+        run: |
+          source poky/oe-init-build-env build
+          bitbake-layers add-layer ../meta-rauc-qemux86
+          bitbake-layers add-layer ../meta-rauc
+          echo 'INHERIT += "rm_work"' >> conf/local.conf
+          echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
+          echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf
+          echo 'DISTRO_FEATURES:append = " rauc"' >> conf/local.conf
+          echo 'IMAGE_INSTALL:append = " rauc"' >> conf/local.conf
+          echo 'IMAGE_FSTYPES = "tar.bz2 wic"' >> conf/local.conf
+          echo 'WKS_FILE = "qemux86-grub-efi.wks"' >> conf/local.conf
+          echo 'EXTRA_IMAGEDEPENDS += "ovmf"' >> conf/local.conf
+          echo 'PREFERRED_RPROVIDER_virtual-grub-bootconf = "rauc-qemu-grubconf"' >> conf/local.conf
+      - name: bitbake parsing test
+        run: |
+          source poky/oe-init-build-env build
+          bitbake -p

--- a/.github/workflows/meta-rauc-raspberrypi.yml
+++ b/.github/workflows/meta-rauc-raspberrypi.yml
@@ -1,0 +1,49 @@
+name: meta-rauc-raspberrypi CI
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+    paths:
+      - 'meta-rauc-raspberrypi/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'meta-rauc-raspberrypi/**'
+jobs:
+  build:
+    name: meta-rauc-raspberrypi Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install required packages
+        run: |
+          sudo apt-get install diffstat
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Clone poky
+        run: git clone -b master git://git.yoctoproject.org/poky
+      - name: Clone meta-rauc
+        run: git clone -b master https://github.com/rauc/meta-rauc.git
+      - name: Clone meta-raspberrypi
+        run: git clone -b master git://git.yoctoproject.org/meta-raspberrypi
+      - name: Initialize build directory
+        run: |
+          source poky/oe-init-build-env build
+          bitbake-layers add-layer ../meta-rauc
+          bitbake-layers add-layer ../meta-raspberrypi
+          bitbake-layers add-layer ../meta-rauc-raspberrypi
+          echo 'INHERIT += "rm_work"' >> conf/local.conf
+          echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
+          echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf
+          echo 'MACHINE = "raspberrypi4"' >> conf/local.conf
+          echo 'DISTRO_FEATURES:append = " rauc"' >> conf/local.conf
+          echo 'IMAGE_INSTALL:append = " rauc"' >> conf/local.conf
+          echo 'IMAGE_FSTYPES = "ext4"' >> conf/local.conf
+          echo 'WKS_FILE = "sdimage-dual-raspberrypi.wks.in"' >> conf/local.conf
+      - name: bitbake parsing test
+        run: |
+          source poky/oe-init-build-env build
+          bitbake -p

--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
 LAYERDEPENDS_meta-rauc-qemux86 = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemux86 = "kirkstone"
+LAYERSERIES_COMPAT_meta-rauc-qemux86 = "kirkstone mickledore"

--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-raspberrypi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-raspberrypi = "6"
 
 LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
-LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell gatesgarth hardknott honister kirkstone mickledore"
+LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell kirkstone mickledore"


### PR DESCRIPTION
Adds minimal workflows capable of setting up and parsing a valid layer and configuration combination.

This should at least prevent running into obvious issues or incompatibilities with the respective release branch.

The builds trigger only for changes to the respective layer directory.

Updated the layer compatibilities to let the workflow trigger (and to fix master builds).