### PR TITLE
boot-scripts: use itest for comparison, as setexpr calculates in hexa…

### DIFF
--- a/meta-rauc-nxp/recipes-bsp/u-boot/files/boot.cmd
+++ b/meta-rauc-nxp/recipes-bsp/u-boot/files/boot.cmd
@@ -14,7 +14,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
         # stop checking after selecting a slot
 
     elif test "x${BOOT_SLOT}" = "xA"; then
-        if test ${BOOT_A_LEFT} -gt 0; then
+        if itest ${BOOT_A_LEFT} -gt 0; then
             setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
             echo "Booting RAUC slot A"
 
@@ -24,7 +24,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
         fi
 
     elif test "x${BOOT_SLOT}" = "xB"; then
-        if test ${BOOT_B_LEFT} -gt 0; then
+        if itest ${BOOT_B_LEFT} -gt 0; then
             setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
             echo "Booting RAUC slot B"
 

--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -12,7 +12,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   if test "x${bootpart}" != "x"; then
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
-    if test ${BOOT_A_LEFT} -gt 0; then
+    if itest ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Found valid RAUC slot A"
       setenv bootpart "/dev/mmcblk0p2"
@@ -20,7 +20,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setenv BOOT_DEV "mmc 0:2"
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
-    if test ${BOOT_B_LEFT} -gt 0; then
+    if itest ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Found valid RAUC slot B"
       setenv bootpart "/dev/mmcblk0p3"

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/boot.cmd.in
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/boot.cmd.in
@@ -12,7 +12,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
   if test "x${bootpart}" != "x"; then
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
-    if test ${BOOT_A_LEFT} -gt 0; then
+    if itest ${BOOT_A_LEFT} -gt 0; then
       setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       echo "Found valid RAUC slot A"
       setenv bootpart "/dev/mmcblk0p2"
@@ -20,7 +20,7 @@ for BOOT_SLOT in "${BOOT_ORDER}"; do
       setenv BOOT_DEV "mmc 0:2"
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
-    if test ${BOOT_B_LEFT} -gt 0; then
+    if itest ${BOOT_B_LEFT} -gt 0; then
       setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       echo "Found valid RAUC slot B"
       setenv bootpart "/dev/mmcblk0p3"

--- a/meta-rauc-tegra/recipes-bsp/u-boot-tegra/files/0001-include-configs-p2771-0000.h-Enable-RAUC.patch
+++ b/meta-rauc-tegra/recipes-bsp/u-boot-tegra/files/0001-include-configs-p2771-0000.h-Enable-RAUC.patch
@@ -27,14 +27,14 @@ index 6f36a0d2c4..d093a963b9 100644
 +	"  if test \"x${raucslot}\" != \"x\"; then " \
 +	"      echo \"skip remaining slots...\"; " \
 +	"  elif test \"x${BOOT_SLOT}\" = \"xA\"; then " \
-+	"    if test ${BOOT_A_LEFT} -gt 0; then " \
++	"    if itest ${BOOT_A_LEFT} -gt 0; then " \
 +	"      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1; " \
 +	"      echo \"Found valid RAUC slot A\"; " \
 +	"      setenv raucslot \"rauc.slot=A\"; " \
 +	"      setenv raucpart 1; set distro_bootpart 1;" \
 +	"    fi; " \
 +	"  elif test \"x${BOOT_SLOT}\" = \"xB\"; then " \
-+	"    if test ${BOOT_B_LEFT} -gt 0; then " \
++	"    if itest ${BOOT_B_LEFT} -gt 0; then " \
 +	"      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1; " \
 +	"      echo \"Found valid RAUC slot B\"; " \
 +	"      setenv raucslot \"rauc.slot=B\"; " \


### PR DESCRIPTION
…decimal

If you use numbers greater than 9 for the boot attempts, you will get the wrong result for pure letter numbers (A..F). The test command incorrectly leads to the result that e.g. F would not be greater than 0. This leads to an incorrect A/B switchover.