### PR TITLE
qemux86: rauc: system.conf: define example rauc history logger

### DIFF
--- a/meta-rauc-qemux86/recipes-core/rauc/files/qemux86-64/system.conf
+++ b/meta-rauc-qemux86/recipes-core/rauc/files/qemux86-64/system.conf
@@ -7,6 +7,13 @@ data-directory=/data/
 [keyring]
 path=ca.cert.pem
 
+[log.readable]
+filename = rauc-history.log
+
+[log.json]
+filename = rauc-history.json
+format=json
+
 [slot.efi.0]
 device=/dev/sda
 type=boot-gpt-switch


### PR DESCRIPTION
For demonstration purpose, this configures the RAUC event logging framework, introduced with RAUC v1.11, to handle two log files: one with a readable installation history, and another with a json-parsable history.