### PR TITLE
qemux86: core-image-minimal: use fixed directory hash seed

### DIFF
--- a/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-qemux86/recipes-core/images/core-image-minimal.bbappend
@@ -7,5 +7,6 @@ do_image_wic[depends] += "boot-image:do_deploy"
 # Optimizations for RAUC adaptive method 'block-hash-index'
 # rootfs image size must to be 4K-aligned
 IMAGE_ROOTFS_ALIGNMENT = "4"
-# ext4 block and inode size should be set to 4K
-EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096"
+# ext4 block size should be set to 4K and use a fixed directory hash seed to
+# reduce the image delta size (keep oe-core's 4K bytes-per-inode)
+EXTRA_IMAGECMD:ext4 = "-i 4096 -b 4096 -E hash_seed=86ca73ff-7379-40bd-a098-fcb03a6e719d"


### PR DESCRIPTION
This avoids some non-determinism in the resulting image, reducing the download size for adaptive RAUC updates.

Also fix the comment about 'inode size' which is actually 'bytes-per-inode' from the original oe-core setting of `EXTRA_IMAGECMD`.