### PR TITLE
rpi: Auto grow the actual /home partition.

### DIFF
--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-raspberrypi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-raspberrypi = "6"
 
 LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
-LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell kirkstone mickledore nanbield"
+LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell kirkstone mickledore nanbield scarthgap"

--- a/meta-rauc-raspberrypi/recipes-core/rauc/files/rauc-grow-data-partition.service
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/files/rauc-grow-data-partition.service
@@ -7,6 +7,7 @@ Before=home.mount
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/parted --script /dev/mmcblk0 resizepart 4 100%
+ExecStart=/usr/sbin/parted --script /dev/mmcblk0 resizepart 6 100%
 
 [Install]
 WantedBy=home.mount

--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc-conf.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc-conf.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append := " file://ca.cert.pem "

--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append := "  \
-	file://system.conf \
-	file://ca.cert.pem \
 	file://rauc-grow-data-partition.service \
 "
 


### PR DESCRIPTION
With the current service, only the extended partition is expanded to fill the space. This also extends partition 6 which is the current /home and the last partition on the disk.