### PR TITLE
BeagleBone Black: Support Scarthgap

### DIFF
--- a/meta-rauc-beaglebone/conf/layer.conf
+++ b/meta-rauc-beaglebone/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-beaglebone = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-beaglebone = "6"
 
 LAYERDEPENDS_meta-rauc-beaglebone = "core rauc yoctobsp"
-LAYERSERIES_COMPAT_meta-rauc-beaglebone = "kirkstone nanbield"
+LAYERSERIES_COMPAT_meta-rauc-beaglebone = "scarthgap"

--- a/meta-rauc-beaglebone/recipes-bsp/u-boot/files/0001-am335x_evm_defconfig-rauc.patch
+++ b/meta-rauc-beaglebone/recipes-bsp/u-boot/files/0001-am335x_evm_defconfig-rauc.patch
@@ -1,44 +1,44 @@
-From f03d92ceeb8ac190a842f24c51669f46b03c1aed Mon Sep 17 00:00:00 2001
+From a367dab84601052ef0059070ab712545c18a1efa Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
-Date: Tue, 23 Jan 2024 12:06:48 +0000
+Date: Thu, 28 Mar 2024 14:43:30 +0000
 Subject: [PATCH] am335x_evm_defconfig: RAUC
+
+Upstream-Status: Inappropriate [RAUC specific]
 
 Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
 ---
- configs/am335x_evm_defconfig | 9 +++++++--
- 1 file changed, 7 insertions(+), 2 deletions(-)
+ configs/am335x_evm_defconfig | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/configs/am335x_evm_defconfig b/configs/am335x_evm_defconfig
-index 4dc5d0fe34..450933641f 100644
+index f048e60f7f..44ef386a90 100644
 --- a/configs/am335x_evm_defconfig
 +++ b/configs/am335x_evm_defconfig
-@@ -9,7 +9,7 @@ CONFIG_DISTRO_DEFAULTS=y
+@@ -16,7 +16,7 @@ CONFIG_TIMESTAMP=y
  CONFIG_SPL_LOAD_FIT=y
- # CONFIG_USE_SPL_FIT_GENERATOR is not set
+ CONFIG_DISTRO_DEFAULTS=y
  CONFIG_OF_BOARD_SETUP=y
 -CONFIG_BOOTCOMMAND="run findfdt; run init_console; run finduuid; run distro_bootcmd"
 +CONFIG_BOOTCOMMAND="load mmc 0:1 $loadaddr boot.scr; source $loadaddr"
  CONFIG_LOGLEVEL=3
  CONFIG_SYS_CONSOLE_INFO_QUIET=y
  CONFIG_ARCH_MISC_INIT=y
-@@ -31,7 +31,7 @@ CONFIG_CMD_SPL_NAND_OFS=0x00080000
+@@ -47,7 +47,7 @@ CONFIG_CMD_SPL_NAND_OFS=0x00080000
  CONFIG_SYS_I2C_EEPROM_ADDR_LEN=2
  # CONFIG_CMD_FLASH is not set
  CONFIG_CMD_NAND=y
 -# CONFIG_CMD_SETEXPR is not set
-+CMD_SETEXPR=y
++CONFIG_CMD_SETEXPR=y
  CONFIG_BOOTP_DNS2=y
  CONFIG_CMD_MTDPARTS=y
  CONFIG_MTDIDS_DEFAULT="nand0=nand.0"
-@@ -101,3 +101,8 @@ CONFIG_WDT=y
+@@ -124,3 +124,6 @@ CONFIG_WDT=y
  CONFIG_DYNAMIC_CRC_TABLE=y
  CONFIG_RSA=y
  CONFIG_LZO=y
 +CONFIG_ENV_EXT4_INTERFACE="mmc"
 +CONFIG_ENV_EXT4_DEVICE_AND_PART="0:1"
 +CONFIG_ENV_EXT4_FILE="/boot/uboot.env"
-+
-+
 -- 
-2.39.2
+2.44.0
 

--- a/meta-rauc-beaglebone/recipes-core/rauc/rauc-conf.bbappend
+++ b/meta-rauc-beaglebone/recipes-core/rauc/rauc-conf.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append := " file://ca.cert.pem "

--- a/meta-rauc-beaglebone/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-beaglebone/recipes-core/rauc/rauc_%.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append := "  \
-	file://system.conf \
-	file://ca.cert.pem \
 	file://rauc-grow-data-partition.service \
 "
 


### PR DESCRIPTION
Changes to support the Yocto Project release Scarthgap and drop support of previous releases because of changes in U-Boot version and in meta-rauc.