### PR TITLE
meta-rauc-raspberrypi: Nanbield and Scarthgap

### DIFF
--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-raspberrypi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-raspberrypi = "6"
 
 LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
-LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "dunfell kirkstone mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "nanbield scarthgap"


### PR DESCRIPTION
Align LAYERSERIES_COMPAT with meta-rauc as of the moment to support Yocto releases Nanbield and Scarthgap.