### PR TITLE
scarthgap/raspberrypi5 u-boot and example certs generation

### DIFF
--- a/create-example-keys.sh
+++ b/create-example-keys.sh
@@ -26,41 +26,48 @@ echo 01 > $BASE/serial
 
 cat > $BASE/openssl.cnf <<EOF
 [ ca ]
-default_ca      = CA_default            # The default ca section
+default_ca      = CA_default               # The default ca section
 
 [ CA_default ]
 
-dir            = .                     # top dir
-database       = \$dir/index.txt        # index file.
-new_certs_dir  = \$dir/certs            # new certs dir
+dir            = .                         # top dir
+database       = \$dir/index.txt           # index file.
+new_certs_dir  = \$dir/certs               # new certs dir
 
-certificate    = \$dir/ca.cert.pem       # The CA cert
-serial         = \$dir/serial           # serial no file
-private_key    = \$dir/private/ca.key.pem# CA private key
-RANDFILE       = \$dir/private/.rand    # random number file
+certificate    = \$dir/ca.cert.pem         # The CA cert
+serial         = \$dir/serial              # serial no file
+private_key    = \$dir/private/ca.key.pem  # CA private key
+RANDFILE       = \$dir/private/.rand       # random number file
 
 default_startdate = 19700101000000Z
 default_enddate = 99991231235959Z
-default_crl_days= 30                   # how long before next CRL
-default_md     = sha256                # md to use
+default_crl_days= 30                       # how long before next CRL
+default_md     = sha256                    # md to use
 
-policy         = policy_any            # default policy
-email_in_dn    = no                    # Don't add the email into cert DN
+policy         = policy_any                # default policy
+email_in_dn    = no                        # Don't add the email into cert DN
 
-name_opt       = ca_default            # Subject name display option
-cert_opt       = ca_default            # Certificate display option
-copy_extensions = none                 # Don't copy extensions from request
+name_opt       = ca_default                # Subject name display option
+cert_opt       = ca_default                # Certificate display option
+copy_extensions = none                     # Don't copy extensions from request
 
 [ policy_any ]
 organizationName       = match
 commonName             = supplied
 
 [ req ]
-default_bits           = 2048
+default_bits           = 4096
 distinguished_name     = req_distinguished_name
 x509_extensions        = v3_leaf
 encrypt_key = no
 default_md = sha256
+attributes             = req_attributes
+prompt                 = no
+input_password         = rauc
+output_password        = rauc
+
+[ req_attributes ]
+challengePassword              = Robust Auto-Update Controller
 
 [ req_distinguished_name ]
 commonName                     = Common Name (eg, YOUR name)
@@ -90,12 +97,13 @@ export OPENSSL_CONF=$BASE/openssl.cnf
 cd $BASE
 
 echo "Development CA"
-openssl req -newkey rsa -keyout private/ca.key.pem -out ca.csr.pem -subj "/O=$ORG/CN=$ORG $CA Development"
-openssl ca -batch -selfsign -extensions v3_ca -in ca.csr.pem -out ca.cert.pem -keyfile private/ca.key.pem
+oe-run-native openssl-native openssl req -config $OPENSSL_CONF -newkey rsa:4096 -keyout private/ca.key.pem -out ca.csr.pem -subj "/O=$ORG/CN=$ORG $CA Development"
+
+oe-run-native openssl-native openssl ca -config $OPENSSL_CONF -batch -selfsign -extensions v3_ca -in ca.csr.pem -out ca.cert.pem -keyfile private/ca.key.pem
 
 echo "Development Signing Keys 1"
-openssl req -newkey rsa -keyout private/development-1.key.pem -out development-1.csr.pem -subj "/O=$ORG/CN=$ORG Development-1"
-openssl ca -batch -extensions v3_leaf -in development-1.csr.pem -out development-1.cert.pem
+oe-run-native openssl-native openssl req -config $OPENSSL_CONF -newkey rsa:4096 -keyout private/development-1.key.pem -out development-1.csr.pem -subj "/O=$ORG/CN=$ORG Development-1"
+oe-run-native openssl-native openssl ca -config $OPENSSL_CONF -batch -extensions v3_leaf -in development-1.csr.pem -out development-1.cert.pem
 
 
 CONFFILE=${BUILDDIR}/conf/site.conf

--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -10,4 +10,7 @@ BBFILE_PATTERN_meta-rauc-raspberrypi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-raspberrypi = "6"
 
 LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
+# For u-boot support for raspberrypi5
+# https://git.yoctoproject.org/meta-lts-mixins scarthgap/u-boot branch
+LAYERRECOMMENDS_meta-rauc-raspberrypi = "lts-u-boot-mixin"
 LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "nanbield scarthgap"

--- a/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
@@ -8,9 +8,9 @@ RAUC_BUNDLE_DESCRIPTION = "RAUC Demo Bundle"
 
 RAUC_BUNDLE_FORMAT = "verity"
 
-RAUC_BUNDLE_SLOTS = "rootfs" 
+RAUC_BUNDLE_SLOTS = "rootfs"
 RAUC_SLOT_rootfs = "core-image-minimal"
 RAUC_SLOT_rootfs[fstype] = "ext4"
 
-RAUC_KEY_FILE = "${THISDIR}/files/development-1.key.pem"
-RAUC_CERT_FILE = "${THISDIR}/files/development-1.cert.pem"
+RAUC_KEY_FILE ?= "${THISDIR}/files/development-1.key.pem"
+RAUC_CERT_FILE ?= "${THISDIR}/files/development-1.cert.pem"


### PR DESCRIPTION
1. Enable the u-boot support provided by v2024.04 via the meta-lts-mixins 'scarthgap/u-boot' branch.

2. Fix the `create-example-keys.sh` script to use `openssl-native` built by openembedded instead of relying on host version compatibility.

3. Relax the variable settings in meta-rauc-raspberrypi `update-bundle.bb` for the keys to allow the autogenerated `site.conf` variables from the `create-example-keys.sh` to be functional. This allows the developer to have their own local keys and not rely on the vulnerable, publicly disclosed private keys in the layer.