### PR TITLE
meta-rauc-raspberrypi: README.rst: Add Raspberry Pi 5 dependency

### DIFF
--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -9,6 +9,11 @@ Dependencies
 * URI: https://github.com/rauc/meta-rauc.git
 * URI: https://git.yoctoproject.org/git/meta-raspberrypi
 
+If you want to build for Raspberry Pi 5 you will also need meta-lts-mixins:
+
+* URI: git://git.yoctoproject.org/meta-lts-mixins
+* branch: scarthgap/u-boot
+
 Patches
 =======
 


### PR DESCRIPTION
Raspberry Pi 5 U-Boot support is added in v2024.04.
This version is provided by `meta-lts-mixins` branch `scarthgap/u-boot`.