### PR TITLE
Raspberry Pi: WORKDIR -> UNPACKDIR transition

### DIFF
--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc-conf.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc-conf.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append := " file://ca.cert.pem "
 
 do_install:prepend() {
-	sed -i "s/@@MACHINE@@/${MACHINE}/g" ${WORKDIR}/system.conf
+	sed -i "s/@@MACHINE@@/${MACHINE}/g" ${S}/system.conf
 }

--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
@@ -17,5 +17,5 @@ RDEPENDS:${PN}-grow-data-part += "parted"
 
 do_install:append() {
 	install -d ${D}${systemd_unitdir}/system/
-	install -m 0644 ${WORKDIR}/rauc-grow-data-partition.service ${D}${systemd_unitdir}/system/
+	install -m 0644 ${UNPACKDIR}/rauc-grow-data-partition.service ${D}${systemd_unitdir}/system/
 }


### PR DESCRIPTION
This GitHub pull request adapts to the oe-core rework to enforce a separate directory for unpacking local sources (UNPACKDIR) instead of directly using WORKDIR.

Follows the preliminary guideline from:
https://lists.openembedded.org/g/openembedded-architecture/message/2007