### PR TITLE
Make Kernel A/B updates (as part of rootfs) default behavior for meta-rauc-raspberrypi

### DIFF
--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -75,14 +75,6 @@ It is also recommended, but not strictly necessary, to enable 'systemd'::
 
    INIT_MANAGER = "systemd"
 
-Optionally, to update the Linux kernel using A/B partitions and a RAUC bundle, put the kernel in the rootfs::
-
-   IMAGE_INSTALL:append = " kernel-image"
-
-Optionally, to boot Linux kernel from the rootfs modify ``boot.cmd.in`` and replace ``fatload mmc 0:1 ${kernel_addr_r} @@KERNEL_IMAGETYPE@@`` with::
-
-   load ${BOOT_DEV} ${kernel_addr_r} boot/@@KERNEL_IMAGETYPE@@
-
 Build the minimal system image::
 
    $ bitbake core-image-minimal

--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -41,6 +41,6 @@ else
   reset
 fi
 
-fatload mmc 0:1 ${kernel_addr_r} @@KERNEL_IMAGETYPE@@
+load ${BOOT_DEV} ${kernel_addr_r} boot/@@KERNEL_IMAGETYPE@@
 if test ! -e mmc 0:1 uboot.env; then saveenv; fi;
 @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}

--- a/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,1 @@
+IMAGE_INSTALL:append = " kernel-image kernel-modules"


### PR DESCRIPTION
I have successfully done a kernel update using a RAUC update bundle on Raspberry Pi 5 with these patches and the instructions from the README.rst.