### PR TITLE
qemux86: fix compatibility with `scarthgap`

### DIFF
--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
 LAYERDEPENDS_meta-rauc-qemux86 = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemux86 = "styhead"
+LAYERSERIES_COMPAT_meta-rauc-qemux86 = "scarthgap"

--- a/meta-rauc-qemux86/recipes-bsp/grub/rauc-qemu-grubconf.bb
+++ b/meta-rauc-qemux86/recipes-bsp/grub/rauc-qemu-grubconf.bb
@@ -11,21 +11,20 @@ SRC_URI += " \
     file://grubenv \
     "
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${WORKDIR}"
 
 inherit deploy
 
 do_install() {
         install -d ${D}${EFI_FILES_PATH}
-        install -m 644 ${S}/grub.cfg ${D}${EFI_FILES_PATH}/grub.cfg
+        install -m 644 ${WORKDIR}/grub.cfg ${D}${EFI_FILES_PATH}/grub.cfg
 }
 
 FILES:${PN} += "${EFI_FILES_PATH}"
 
 do_deploy() {
-	install -m 644 ${S}/grub.cfg ${DEPLOYDIR}
-	install -m 644 ${S}/grubenv ${DEPLOYDIR}
+	install -m 644 ${WORKDIR}/grub.cfg ${DEPLOYDIR}
+	install -m 644 ${WORKDIR}/grubenv ${DEPLOYDIR}
 }
 
 addtask deploy after do_install before do_build


### PR DESCRIPTION
This reverts two commits that were not intended for `scarthgap` but ended up before the `scarthgap` branch point.