### PR TITLE
Pin CI Jobs to 'scarthgap'

### DIFF
--- a/.github/workflows/meta-rauc-qemux86.yml
+++ b/.github/workflows/meta-rauc-qemux86.yml
@@ -2,15 +2,15 @@ name: meta-rauc-qemux86 CI
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the scarthgap branch
   push:
     branches:
-      - master
+      - scarthgap
     paths:
       - 'meta-rauc-qemux86/**'
   pull_request:
     branches:
-      - master
+      - scarthgap
     paths:
       - 'meta-rauc-qemux86/**'
 jobs:
@@ -24,9 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Clone poky
-        run: git clone -b master git://git.yoctoproject.org/poky
+        run: git clone -b scarthgap git://git.yoctoproject.org/poky
       - name: Clone meta-rauc
-        run: git clone -b master https://github.com/rauc/meta-rauc.git
+        run: git clone -b scarthgap https://github.com/rauc/meta-rauc.git
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build

--- a/.github/workflows/meta-rauc-raspberrypi.yml
+++ b/.github/workflows/meta-rauc-raspberrypi.yml
@@ -2,15 +2,15 @@ name: meta-rauc-raspberrypi CI
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the scarthgap branch
   push:
     branches:
-      - master
+      - scarthgap
     paths:
       - 'meta-rauc-raspberrypi/**'
   pull_request:
     branches:
-      - master
+      - scarthgap
     paths:
       - 'meta-rauc-raspberrypi/**'
 jobs:
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Clone poky
-        run: git clone -b master git://git.yoctoproject.org/poky
+        run: git clone -b scarthgap git://git.yoctoproject.org/poky
       - name: Clone meta-rauc
-        run: git clone -b master https://github.com/rauc/meta-rauc.git
+        run: git clone -b scarthgap https://github.com/rauc/meta-rauc.git
       - name: Clone meta-raspberrypi
-        run: git clone -b master git://git.yoctoproject.org/meta-raspberrypi
+        run: git clone -b scarthgap git://git.yoctoproject.org/meta-raspberrypi
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build


### PR DESCRIPTION
For 'scarthgap' we need to check against 'scarthgap' instead of 'master'.