### PR TITLE
Fix build failure due to rename of mount.blacklist.d folder in udev-e…

### DIFF
--- a/meta-rauc-beaglebone/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-beaglebone/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " file://bbb-rauc.rules"
 
 do_install:append() {
-    install -m 0644 ${WORKDIR}/bbb-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/bbb-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:cubox-i := "${THISDIR}/files:"
 SRC_URI:append:cubox-i = " file://cubox-i-rauc.rules"
 
 do_install:append:cubox-i() {
-    install -m 0644 ${WORKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-raspberrypi/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/files:"
 SRC_URI:append:rpi = " file://raspberrypi-rauc.rules"
 
 do_install:append:rpi() {
-    install -m 0644 ${WORKDIR}/raspberrypi-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/raspberrypi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-sunxi/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-sunxi/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:sun8i := "${THISDIR}/files:"
 SRC_URI:append:sun8i = " file://sunxi-rauc.rules"
 
 do_install:append:sun8i() {
-    install -m 0644 ${WORKDIR}/sunxi-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/sunxi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }


### PR DESCRIPTION
…xtraconf recipe

This commit addresses a build failure caused by the renaming of the mount.blacklist.d folder in the udev-extraconf recipe, which is part of the openembedded-core. The issue arose following changes made in the upstream commit 69e486ddb3059f80ba538e1f59c2ca8a8df0faf9(https://github.com/openembedded/openembedded-core/commit/69e486ddb3059f80ba538e1f59c2ca8a8df0faf9)