### PR TITLE
meta-rauc-raspberrypi: Styhead

### DIFF
--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -13,4 +13,4 @@ LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
 # For u-boot support for raspberrypi5
 # https://git.yoctoproject.org/meta-lts-mixins scarthgap/u-boot branch
 LAYERRECOMMENDS_meta-rauc-raspberrypi = "lts-u-boot-mixin"
-LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "nanbield scarthgap"
+LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "styhead"


### PR DESCRIPTION
Align LAYERSERIES_COMPAT with meta-rauc as of the moment to support Yocto releases Styhead.