### PR TITLE
meta-rauc-sunxi: Add Merrii A80 Optimus

### DIFF
--- a/meta-rauc-sunxi/README.rst
+++ b/meta-rauc-sunxi/README.rst
@@ -45,6 +45,7 @@ Currently this layer supports:
 - Olimex A20-OLinuXino-MICRO
 - Orange Pi One
 - Orange Pi Zero
+- Merrii A80 Optimus board
 
 
 I. Adding the meta-rauc-sunxi layer to your build

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0005-configs-Merrii_A80_Optimus_defconfig-RAUC.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0005-configs-Merrii_A80_Optimus_defconfig-RAUC.patch
@@ -1,0 +1,30 @@
+From bb8df05b0463e1c0d58813380458a8c59ffad576 Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Tue, 10 Dec 2024 10:00:20 +0000
+Subject: [PATCH] configs/Merrii_A80_Optimus_defconfig: RAUC
+
+Configure U-Boot environment location, size (CONFIG_ENV_SIZE) and
+offset (CONFIG_ENV_OFFSET) on the FAT partition for Merrii A80
+Optimus board and after that use it in /etc/fw_env.config.
+
+Upstream-Status: Inappropriate [RAUC specific]
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ configs/Merrii_A80_Optimus_defconfig | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configs/Merrii_A80_Optimus_defconfig b/configs/Merrii_A80_Optimus_defconfig
+index a26677e1c0..9c79d7aeab 100644
+--- a/configs/Merrii_A80_Optimus_defconfig
++++ b/configs/Merrii_A80_Optimus_defconfig
+@@ -13,3 +13,6 @@ CONFIG_AXP_GPIO=y
+ CONFIG_SYS_I2C_SUN8I_RSB=y
+ CONFIG_REGULATOR_AXP_USB_POWER=y
+ CONFIG_AXP809_POWER=y
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_OFFSET=0x0000
++CONFIG_ENV_IS_IN_FAT=y
+-- 
+2.47.0
+

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -18,6 +18,7 @@ SRC_URI += " \
     file://0002-orangepi_one_defconfig-RAUC.patch \
     file://0003-orangepi_zero_defconfig-RAUC.patch \
     file://0004-configs-A20-OLinuXino_MICRO_defconfig-RAUC.patch \
+    file://0005-configs-Merrii_A80_Optimus_defconfig-RAUC.patch \
 "
 
 UBOOT_ENV_SUFFIX = "scr"


### PR DESCRIPTION
Add support for Merrii A80 Optimus board with Allwinner 80 SoC from the sun9i family.