### PR TITLE
Add Cubieboard4 A80

### DIFF
--- a/meta-rauc-sunxi/README.rst
+++ b/meta-rauc-sunxi/README.rst
@@ -46,6 +46,7 @@ Currently this layer supports:
 - Orange Pi One
 - Orange Pi Zero
 - Merrii A80 Optimus board
+- Cubieboard4 A80
 
 
 I. Adding the meta-rauc-sunxi layer to your build

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0006-Add-support-for-Cubieboard-4-board-with-Allwinner-80.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0006-Add-support-for-Cubieboard-4-board-with-Allwinner-80.patch
@@ -1,0 +1,31 @@
+From 093b6d79694fde0656f97fe6eacf331d9109f028 Mon Sep 17 00:00:00 2001
+From: lazarh <def_58@abv.bg>
+Date: Tue, 10 Dec 2024 16:56:05 +0000
+Subject: [PATCH] Add support for Cubieboard 4 board with Allwinner 80 SoC from
+ the sun9i family.
+
+Configure U-Boot environment location, size (CONFIG_ENV_SIZE) and
+offset (CONFIG_ENV_OFFSET) on the FAT partition for Cubieboard4
+board and after that use it in /etc/fw_env.config.
+
+Upstream-Status: Inappropriate [RAUC specific]
+
+Signed-off-by: Lazar Hristov <lhristov@gmail.com>
+---
+ configs/Cubieboard4_defconfig | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configs/Cubieboard4_defconfig b/configs/Cubieboard4_defconfig
+index d3678ad5c7..2a4accb372 100644
+--- a/configs/Cubieboard4_defconfig
++++ b/configs/Cubieboard4_defconfig
+@@ -13,3 +13,6 @@ CONFIG_AXP_GPIO=y
+ CONFIG_SYS_I2C_SUN8I_RSB=y
+ CONFIG_REGULATOR_AXP_USB_POWER=y
+ CONFIG_AXP809_POWER=y
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_OFFSET=0x0000
++CONFIG_ENV_IS_IN_FAT=y
+-- 
+2.47.0
+

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -19,6 +19,7 @@ SRC_URI += " \
     file://0003-orangepi_zero_defconfig-RAUC.patch \
     file://0004-configs-A20-OLinuXino_MICRO_defconfig-RAUC.patch \
     file://0005-configs-Merrii_A80_Optimus_defconfig-RAUC.patch \
+    file://0006-Add-support-for-Cubieboard-4-board-with-Allwinner-80.patch \
 "
 
 UBOOT_ENV_SUFFIX = "scr"


### PR DESCRIPTION
Add support for Cubieboard4 board with Allwinner 80 SoC from the sun9i family.

Signed-off-by:  Lazar Hristov <lhristov@gmail.com>