### PR TITLE
.github/workflows: generate workflows from template

### DIFF
--- a/.github/workflows/generate.py
+++ b/.github/workflows/generate.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+from jinja2 import Template
+
+TEMPLATE = """
+name: «« layer »» CI
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+    paths:
+      - '«« layer »»/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '«« layer »»/**'
+jobs:
+  build:
+    name: «« layer »» Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install required packages
+        run: |
+          sudo apt-get install diffstat
+      - name: Checkout
+        uses: actions/checkout@v3
+      «% for name, url in base_layers.items()|list + extra_layers.items()|list %»
+      - name: Clone «« name »»
+        run: git clone -b master «« url »»
+      «% endfor %»
+      - name: Initialize build directory
+        run: |
+          source poky/oe-init-build-env build
+          bitbake-layers add-layer ../meta-rauc
+          «% for name in extra_layers.keys() %»
+          bitbake-layers add-layer ../«« name »»
+          «% endfor %»
+          bitbake-layers add-layer ../«« layer »»
+          echo 'INHERIT += "rm_work"' >> conf/local.conf
+          echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
+          echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf
+          «% if machine %»
+          echo 'MACHINE = "«« machine »»"' >> conf/local.conf
+          «% endif %»
+          echo 'DISTRO_FEATURES:append = " rauc"' >> conf/local.conf
+          echo 'IMAGE_INSTALL:append = " rauc"' >> conf/local.conf
+          echo 'IMAGE_FSTYPES = "«« fstypes »»"' >> conf/local.conf
+          echo 'WKS_FILE = "«« wks_file »»"' >> conf/local.conf
+          «% for line in conf %»
+          echo '«« line »»' >> conf/local.conf
+          «% endfor %»
+      - name: bitbake parsing test
+        run: |
+          source poky/oe-init-build-env build
+          bitbake -p
+""".lstrip()
+
+template = Template(
+        TEMPLATE,
+        block_start_string='«%',
+        block_end_string='%»',
+        variable_start_string='««',
+        variable_end_string='»»',
+        comment_start_string='«#',
+        comment_end_string='#»',
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        )
+
+default_context = {
+    "base_layers": {
+        "poky": "git://git.yoctoproject.org/poky",
+        "meta-rauc": "https://github.com/rauc/meta-rauc.git"
+    },
+    "extra_layers": {
+    },
+    "machine": None,
+    "conf": [],
+}
+
+contexts = [
+    {
+        **default_context,
+        "layer": "meta-rauc-qemux86",
+        "fstypes": "tar.bz2 wic",
+        "wks_file": "qemux86-grub-efi.wks",
+        "conf": [
+            'EXTRA_IMAGEDEPENDS += "ovmf"',
+            'PREFERRED_RPROVIDER_virtual-grub-bootconf = "rauc-qemu-grubconf"',
+        ],
+    },
+    {
+        **default_context,
+        "layer": "meta-rauc-raspberrypi",
+        "extra_layers": {
+            "meta-raspberrypi": "git://git.yoctoproject.org/meta-raspberrypi",
+        },
+        "machine": "raspberrypi4",
+        "fstypes": "ext4",
+        "wks_file": "sdimage-dual-raspberrypi.wks.in",
+    },
+]
+
+for context in contexts:
+    output = template.render(context)
+    file_name = f"{context['layer']}.yml"
+    with open(file_name, "w") as file:
+        file.write(output)
+    print(f"generated {file_name}")

--- a/.github/workflows/meta-rauc-qemux86.yml
+++ b/.github/workflows/meta-rauc-qemux86.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Initialize build directory
         run: |
           source poky/oe-init-build-env build
-          bitbake-layers add-layer ../meta-rauc-qemux86
           bitbake-layers add-layer ../meta-rauc
+          bitbake-layers add-layer ../meta-rauc-qemux86
           echo 'INHERIT += "rm_work"' >> conf/local.conf
           echo 'DISTRO_FEATURES:remove = "alsa bluetooth usbgadget usbhost wifi nfs zeroconf pci 3g nfc x11 opengl ptest wayland vulkan"' >> conf/local.conf
           echo 'SSTATE_MIRRORS = "file://.* http://195.201.147.117/sstate-cache/PATH"' >> conf/local.conf


### PR DESCRIPTION
We want to build more layers in CI while avoiding too much redundancy in the workflow definitions. Although this could be done using reusable workflows or custom actions, templating them using jinja is much simpler and more flexible.

To avoid conflicts with the GitHub Actions syntax, we use « and » instead of { and }.

The only change to the existing workflows is the order in which 'bitbake-layers add-layer' is run.