### PR TITLE
Scarthgap: Raspberry Pi: core-image-minimal.bbappend: Remove kernel

### DIFF
--- a/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
@@ -1,1 +1,5 @@
+# Store the kernel in the rootfs partition
 IMAGE_INSTALL:append = " kernel-image kernel-modules"
+
+# Remove the kernel from the /boot partition because it is in rootfs
+RPI_EXTRA_IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE}"


### PR DESCRIPTION
Use RPI_EXTRA_IMAGE_BOOT_FILES to remove the kernel from the /boot partition because it is in rootfs.

Reported-by: Andrey Ezhkov <andrey.ezhkov@konsulko.com>