### PR TITLE
Fix udev-extraconf_%.bbappend

### DIFF
--- a/meta-rauc-beaglebone/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-beaglebone/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " file://bbb-rauc.rules"
 
 do_install:append() {
-    install -m 0644 ${WORKDIR}/bbb-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
+    install -m 0644 ${UNPACKDIR}/bbb-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-beaglebone/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-beaglebone/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " file://bbb-rauc.rules"
 
 do_install:append() {
-    install -m 0644 ${WORKDIR}/bbb-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/bbb-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:cubox-i := "${THISDIR}/files:"
 SRC_URI:append:cubox-i = " file://cubox-i-rauc.rules"
 
 do_install:append:cubox-i() {
-    install -m 0644 ${WORKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:cubox-i := "${THISDIR}/files:"
 SRC_URI:append:cubox-i = " file://cubox-i-rauc.rules"
 
 do_install:append:cubox-i() {
-    install -m 0644 ${WORKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
+    install -m 0644 ${UNPACKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-raspberrypi/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/files:"
 SRC_URI:append:rpi = " file://raspberrypi-rauc.rules"
 
 do_install:append:rpi() {
-    install -m 0644 ${WORKDIR}/raspberrypi-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/raspberrypi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-raspberrypi/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/files:"
 SRC_URI:append:rpi = " file://raspberrypi-rauc.rules"
 
 do_install:append:rpi() {
-    install -m 0644 ${WORKDIR}/raspberrypi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
+    install -m 0644 ${UNPACKDIR}/raspberrypi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-sunxi/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-sunxi/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:sun8i := "${THISDIR}/files:"
 SRC_URI:append:sun8i = " file://sunxi-rauc.rules"
 
 do_install:append:sun8i() {
-    install -m 0644 ${WORKDIR}/sunxi-rauc.rules ${D}${sysconfdir}/udev/mount.blacklist.d/
+    install -m 0644 ${WORKDIR}/sunxi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }

--- a/meta-rauc-sunxi/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-sunxi/recipes-core/udev/udev-extraconf_%.bbappend
@@ -2,5 +2,5 @@ FILESEXTRAPATHS:prepend:sun8i := "${THISDIR}/files:"
 SRC_URI:append:sun8i = " file://sunxi-rauc.rules"
 
 do_install:append:sun8i() {
-    install -m 0644 ${WORKDIR}/sunxi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
+    install -m 0644 ${UNPACKDIR}/sunxi-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }


### PR DESCRIPTION
Fix `udev-extraconf_%.bbappend`:

- Cherry pick commit 3d85c19c99837789ad3e5c2a4ffe50c79c338bb8 to master.
- Replace `WORKDIR` with `UNPACKDIR` for all supported devices in `do_instal`l from `udev-extraconf_%.bbappend`.