### PR TITLE
meta-rauc-st-stm32mp: rauc.rules: mmcblk1

### DIFF
--- a/meta-rauc-st-stm32mp/recipes-core/udev/files/rauc.rules
+++ b/meta-rauc-st-stm32mp/recipes-core/udev/files/rauc.rules
@@ -2,3 +2,5 @@
 /dev/disk/by-path/platform-soc-amba-58005000.mmc-part11
 /dev/mmcblk0p10
 /dev/mmcblk0p11
+/dev/mmcblk1p10
+/dev/mmcblk1p11


### PR DESCRIPTION
The enumeration of storage sometimes may change to mmcblk1. Add mmcblk1p10 and mmcblk1p11 to ignore list to avoid mounting the A and the B partitions when udev-extraconf is included in the image.

Follow-up fix for #150.