### PR TITLE
.github/workflows: run on ubuntu 22.04 for python > 3.8.x

### DIFF
--- a/.github/workflows/meta-rauc-qemux86.yml
+++ b/.github/workflows/meta-rauc-qemux86.yml
@@ -16,11 +16,11 @@ on:
 jobs:
   build:
     name: meta-rauc-qemux86 Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat
+          sudo apt-get install diffstat chrpath
       - name: Checkout
         uses: actions/checkout@v3
       - name: Clone poky

--- a/.github/workflows/meta-rauc-raspberrypi.yml
+++ b/.github/workflows/meta-rauc-raspberrypi.yml
@@ -16,11 +16,11 @@ on:
 jobs:
   build:
     name: meta-rauc-raspberrypi Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat
+          sudo apt-get install diffstat chrpath
       - name: Checkout
         uses: actions/checkout@v3
       - name: Clone poky


### PR DESCRIPTION
Since walnascar, the minimum required bitbake version will be 3.9.0:

> RuntimeError: Sorry, python 3.9.0 or later is required for this version of bitbake

This will allow continuing to run the GitHub actions on the GH-hosted runners.

Also, explicitly install 'chrpath', which does not seem to be part of the default installation anymore.