### PR TITLE
qemuarm: Default to walnascar release

### DIFF
--- a/meta-rauc-qemuarm/conf/layer.conf
+++ b/meta-rauc-qemuarm/conf/layer.conf
@@ -9,8 +9,8 @@ BBFILE_COLLECTIONS += "meta-rauc-qemuarm"
 BBFILE_PATTERN_meta-rauc-qemuarm = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemuarm = "6"
 
-LAYERDEPENDS_meta-rauc-qemuarm = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemuarm = "styhead"
+LAYERDEPENDS_meta-rauc-qemuarm = "core rauc"
+LAYERSERIES_COMPAT_meta-rauc-qemuarm = "styhead walnascar"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"

--- a/meta-rauc-qemuarm/kas-qemuarm.yml
+++ b/meta-rauc-qemuarm/kas-qemuarm.yml
@@ -6,7 +6,7 @@ distro: poky
 
 defaults:
   repos:
-    branch: styhead
+    branch: walnascar
 
 repos:
   meta-rauc-community:
@@ -14,6 +14,7 @@ repos:
       meta-rauc-qemuarm:
   meta-rauc:
     url: "https://github.com/rauc/meta-rauc.git"
+    branch: master
     path: layers/meta-rauc
   poky:
     url: "https://git.yoctoproject.org/git/poky"

--- a/meta-rauc-qemuarm/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-rauc-qemuarm/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -27,7 +27,7 @@ SRC_URI += " \
 RDEPENDS:${PN} = " kernel-devicetree"
 
 KERNEL_DEVICETREE:qemuarm = "qemuarm.dtb"
-KERNEL_BOOTCMD:qemuarm = "bootm"
+KERNEL_BOOTCMD:qemuarm = "bootz"
 KERNEL_DEVICETREE:qemuarm64 = "qemuarm64.dtb"
 KERNEL_BOOTCMD:qemuarm64 = "booti"
 


### PR DESCRIPTION
Add support for `walnascar` poky release, for both `qemuarm64` and `qemuarm` machines.

Supposedly also fixes a minor bug for the u-boot script for `qemuarm`.