### PR TITLE
.github/workflows: update generator for ubuntu-22.04

### DIFF
--- a/.github/workflows/generate.py
+++ b/.github/workflows/generate.py
@@ -21,11 +21,11 @@ on:
 jobs:
   build:
     name: «« layer »» Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install required packages
         run: |
-          sudo apt-get install diffstat
+          sudo apt-get install diffstat chrpath
       - name: Checkout
         uses: actions/checkout@v3
       «% for name, url in base_layers.items()|list + extra_layers.items()|list %»


### PR DESCRIPTION
The result matches to repository contents again.

Fixes: 6613e7fc25a6 (".github/workflows: run on ubuntu 22.04 for python > 3.8.x")