### PR TITLE
recipes-bsp/u-boot/files/rpi_arm64_defconfig.patch: re-align path

### DIFF
--- a/meta-rauc-raspberrypi/recipes-bsp/u-boot/files/rpi_arm64_defconfig.patch
+++ b/meta-rauc-raspberrypi/recipes-bsp/u-boot/files/rpi_arm64_defconfig.patch
@@ -8,19 +8,15 @@ Enable squashfs support in u-boot for rpi_arm64_defconfig so we can boot
 the kernel directly from A/B rootfs.
 
 Signed-off-by: Kevin Read <kread@om7sense.com>
----
- configs/rpi_arm64_defconfig | 7 +++++--
- 1 file changed, 5 insertions(+), 2 deletions(-)
 
-diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
-index 08bb30b1d7a..c686b737381 100644
---- a/configs/rpi_arm64_defconfig
-+++ b/configs/rpi_arm64_defconfig
-@@ -57,3 +57,6 @@ CONFIG_SYS_WHITE_ON_BLACK=y
- CONFIG_VIDEO_BCM2835=y
+Index: git/configs/rpi_arm64_defconfig
+===================================================================
+--- git.orig/configs/rpi_arm64_defconfig
++++ git/configs/rpi_arm64_defconfig
+@@ -64,3 +64,6 @@ CONFIG_VIDEO_BCM2835=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
+ # CONFIG_HEXDUMP is not set
 +# squashfs support
 +CONFIG_FS_SQUASHFS=y
 +CONFIG_CMD_SQUASHFS=y
-


### PR DESCRIPTION
This failed as u-boot version changed in meta-lts-mixins https://git.yoctoproject.org/meta-lts-mixins/commit/?h=scarthgap/u-boot&id=68856926465b56b98599ab2506fceb0d1bcfad5b