### PR TITLE
meta-rauc-raspberrypi/conf/layer.conf: Whinlatter

### DIFF
--- a/meta-rauc-raspberrypi/conf/layer.conf
+++ b/meta-rauc-raspberrypi/conf/layer.conf
@@ -13,7 +13,7 @@ LAYERDEPENDS_meta-rauc-raspberrypi = "core rauc raspberrypi"
 # For u-boot support for raspberrypi5
 # https://git.yoctoproject.org/meta-lts-mixins scarthgap/u-boot branch
 LAYERRECOMMENDS_meta-rauc-raspberrypi = "lts-u-boot-mixin"
-LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "styhead walnascar"
+LAYERSERIES_COMPAT_meta-rauc-raspberrypi = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"


### PR DESCRIPTION
Add support for release Whinlatter in meta-rauc-raspberrypi.