### PR TITLE
meta-rauc-qemuarm: Canonical solution for devicetree

### DIFF
--- a/meta-rauc-qemuarm/conf/layer.conf
+++ b/meta-rauc-qemuarm/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-rauc-qemuarm = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemuarm = "6"
 
 LAYERDEPENDS_meta-rauc-qemuarm = "core rauc"
-LAYERSERIES_COMPAT_meta-rauc-qemuarm = "styhead walnascar"
+LAYERSERIES_COMPAT_meta-rauc-qemuarm = "styhead walnascar whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"

--- a/meta-rauc-qemuarm/recipes-bsp/u-boot/files/boot.cmd.in
+++ b/meta-rauc-qemuarm/recipes-bsp/u-boot/files/boot.cmd.in
@@ -42,7 +42,7 @@ if test "x${rauc_slot}" = "x"; then
 fi
 
 echo "=== Loading device tree from p${rootfs_partition} to ${fdt_addr} ==="
-ext4load virtio ${virtio_device_num}:${rootfs_partition} ${fdt_addr} /boot/@@KERNEL_DEVICETREE@@
+ext4load virtio ${virtio_device_num}:${rootfs_partition} ${fdt_addr} /boot/devicetree/@@DEVICETREE_NAME@@
 
 echo "=== Loading kernel image from p${rootfs_partition} to ${kernel_addr_r} ==="
 ext4load virtio ${virtio_device_num}:${rootfs_partition} ${kernel_addr_r} /boot/@@KERNEL_IMAGETYPE@@

--- a/meta-rauc-qemuarm/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-rauc-qemuarm/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -24,31 +24,26 @@ SRC_URI += " \
 "
 
 # The boot script loads the devicetree from the rootfs, so we need to make sure it's deployed.
-RDEPENDS:${PN} = " kernel-devicetree"
+RDEPENDS:${PN} = " devicetree-qemuarm"
+DEVICETREE_NAME = "${MACHINE}.dtb"
 
-KERNEL_DEVICETREE:qemuarm = "qemuarm.dtb"
 KERNEL_BOOTCMD:qemuarm = "bootz"
-KERNEL_DEVICETREE:qemuarm64 = "qemuarm64.dtb"
 KERNEL_BOOTCMD:qemuarm64 = "booti"
 
 # Compile the boot.scr and make it available in the DEPLOYDIR
-UBOOT_ENV:qemuarm = "boot"
-UBOOT_ENV:qemuarm64 = "boot"
-UBOOT_ENV_SUFFIX:qemuarm = "scr"
-UBOOT_ENV_SUFFIX:qemuarm64 = "scr"
+UBOOT_ENV = "boot"
+UBOOT_ENV_SUFFIX = "scr"
 
 # Set the required entrypoint and loadaddress
 # These are usually 00008000 for ARM machines
-UBOOT_ENTRYPOINT:qemuarm = "0x00008000"
-UBOOT_ENTRYPOINT:qemuarm64 = "0x00008000"
-UBOOT_LOADADDRESS:qemuarm = "0x00008000"
-UBOOT_LOADADDRESS:qemuarm64 = "0x00008000"
+UBOOT_ENTRYPOINT = "0x00008000"
+UBOOT_LOADADDRESS = "0x00008000"
 
 # Provide the empty flash image to persist the bootloader environment
 UBOOT_BOOTENV_FILE = "bootenv.img"
 
 do_configure:prepend () {
-    sed -e 's/@@KERNEL_DEVICETREE@@/${KERNEL_DEVICETREE}/' \
+    sed -e 's/@@DEVICETREE_NAME@@/${DEVICETREE_NAME}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         "${UNPACKDIR}/boot.cmd.in" > "${UNPACKDIR}/boot.cmd"

--- a/meta-rauc-qemuarm/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-qemuarm/recipes-core/images/core-image-minimal.bbappend
@@ -5,7 +5,7 @@ IMAGE_INSTALL:append = " \
     u-boot-fw-utils \
     u-boot-default-env \
     kernel-image \
-    kernel-devicetree \
+    devicetree-qemuarm \
     rauc \
     e2fsprogs-mke2fs \
     mtd-utils \

--- a/meta-rauc-qemuarm/recipes-kernel/linux/devicetree-qemuarm_1.0.bb
+++ b/meta-rauc-qemuarm/recipes-kernel/linux/devicetree-qemuarm_1.0.bb
@@ -1,0 +1,15 @@
+# ---
+# Out-of-tree device tree for the qemuarm/qemuarm64 machines.
+#
+# As we don't boot the kernel directly from QEMU (instead u-boot does)
+# and more control of the DT may be useful, this package provides the DT
+# as dumped by QEMU (using the '-machine dumpdtb=<name>.dtb' option).
+
+SUMMARY = "Provides an out-of-tree devicetree for the qemuarm/qemuarm64 machine."
+
+inherit devicetree
+
+SRC_URI:qemuarm = "file://qemuarm.dts"
+SRC_URI:qemuarm64 = "file://qemuarm64.dts"
+
+COMPATIBLE_MACHINE = "^(qemuarm|qemuarm64)$"

--- a/meta-rauc-qemuarm/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-rauc-qemuarm/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,28 +1,11 @@
 # ---
 # qemuarm specific kernel extensions and configurations
 #
-# This also injects the kernel configuration required to interact with the bootloader environment.
+# Provides the kernel configuration required to interact with the bootloader environment.
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI:append = " file://mtd_flash.cfg"
-SRC_URI:append:qemuarm = " file://qemuarm.dts"
-SRC_URI:append:qemuarm64 = " file://qemuarm64.dts"
-
 
 # Architecture specific kernel configuration
-KERNEL_DEVICETREE:qemuarm = "qemuarm.dtb"
-KERNEL_DEVICETREE:qemuarm64 = "qemuarm64.dtb"
-KERNEL_EXTRA_ARGS:qemuarm += "LOADADDR=${UBOOT_ENTRYPOINT}"
-KERNEL_EXTRA_ARGS:qemuarm64 += "LOADADDR=${UBOOT_ENTRYPOINT}"
-
-# Instead of patching the DTS into the kernel tree, copy it to allow easier modification of the file.
-do_configure:append:qemuarm() {
-    cp ${UNPACKDIR}/qemuarm.dts ${S}/arch/arm/boot/dts
-    echo "dtb-$(CONFIG_ARCH_QEMU) += qemuarm.dtb" >> ${S}/arch/arm/boot/dts/Makefile
-}
-
-do_configure:append:qemuarm64() {
-    cp ${UNPACKDIR}/qemuarm64.dts ${S}/arch/arm64/boot/dts
-    echo "dtb-$(CONFIG_ARCH_QEMU) += qemuarm64.dtb" >> ${S}/arch/arm64/boot/dts/Makefile
-}
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"


### PR DESCRIPTION
Instead of patching the kernel source tree, the `devicetree.bbclass` provides a clean way to provide out-of-tree device trees. Hence, this PR implements the canonical solution and introduces a dedicated `devicetree-qemuarm` package for the static device tree dumped from QEMU.

Besides, some parts of the code are simplified.

This is a follow-up of the initial PR series to add support for the `qemuarm` and `qemuarm64` machines.