### PR TITLE
meta-rauc-nxp: rauc: use IMX_DEFAULT_BOOTLOADER

### DIFF
--- a/meta-rauc-nxp/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-nxp/recipes-core/rauc/rauc_%.bbappend
@@ -5,7 +5,7 @@ SRC_URI:append := "  \
 	file://grow-data-partition.sh \
 "
 
-RDEPENDS:${PN} += "u-boot-fw-utils u-boot-imx-env"
+RDEPENDS:${PN} += "u-boot-fw-utils ${IMX_DEFAULT_BOOTLOADER}-env"
 DEPENDS += "u-boot"
 
 inherit systemd


### PR DESCRIPTION
The RAUC recipe adds a runtime dependency on u-boot-imx for NXP SoCs.

However, the meta-freescale layer supports multiple U-Boot variants:
 - u-boot-fslc
 - u-boot-imx
 - u-boot-boundary
 - u-boot-toradex

As a result, the current RAUC recipe only works correctly when u-boot-imx is used as the bootloader.

The bootloader selection is controlled through the preferred virtual provider PREFERRED_PROVIDER_virtual/bootloader, which is defined by the NXP-specific variable IMX_DEFAULT_BOOTLOADER[1][2]. If not overridden by the machine configuration or local.conf, this variable defaults to u-boot-fslc.

Each U-Boot recipe provides environment configuration files and an associated package ${PN}-env[3], resulting in:
 - u-boot-fslc-env
 - u-boot-imx-env
 - u-boot-boundary-env
 - u-boot-toradex-env

For example, the i.MX7 Dual SABRE machine does not override IMX_DEFAULT_BOOTLOADER and therefore uses u-boot-fslc. Since RAUC depends on u-boot-imx-env, which is not built in this configuration, a do_rootfs error occurs when building the image.

This change updates the RAUC recipe to use IMX_DEFAULT_BOOTLOADER to select the correct bootloader environment package for the runtime dependency.

Fixes:

	NOTE: Resolving any missing task queue dependencies
	ERROR: Nothing RPROVIDES 'u-boot-imx-env' (but /home/gportay/src/meta-imx7dsabresd/build/../meta-rauc/recipes-core/rauc/rauc_1.14.bb RDEPENDS on or otherwise requires it)
	u-boot-imx RPROVIDES u-boot-imx-env but was skipped: PREFERRED_PROVIDER_virtual/bootloader set to u-boot-fslc, not u-boot-imx
	NOTE: Runtime target 'u-boot-imx-env' is unbuildable, removing...
	Missing or unbuildable dependency chain was: ['u-boot-imx-env']
	NOTE: Runtime target 'rauc' is unbuildable, removing...
	Missing or unbuildable dependency chain was: ['rauc', 'u-boot-imx-env']
	ERROR: Required build target 'core-image-minimal' has no buildable providers.
	Missing or unbuildable dependency chain was: ['core-image-minimal', 'rauc', 'u-boot-imx-env']

[1]: https://github.com/Freescale/meta-freescale/blob/3284a5a01820f01ac4dac585d51c18eaeb064fb7/conf/machine/include/imx-base.inc#L21
[2]: https://github.com/Freescale/meta-freescale/blob/9b6c142bc0fab96f8ce1830555850e9e3215bda0/conf/machine/include/imx-base.inc#L12-L13
[3]: https://git.yoctoproject.org/poky/tree/meta/recipes-bsp/u-boot/u-boot.inc?h=4882a93566f2ef24787777#n244