### PR TITLE
qemuarm: Fix compilation for walnascar release.

### DIFF
--- a/meta-rauc-qemuarm/kas-qemuarm.yml
+++ b/meta-rauc-qemuarm/kas-qemuarm.yml
@@ -14,7 +14,6 @@ repos:
       meta-rauc-qemuarm:
   meta-rauc:
     url: "https://github.com/rauc/meta-rauc.git"
-    branch: master
     path: layers/meta-rauc
   poky:
     url: "https://git.yoctoproject.org/git/poky"


### PR DESCRIPTION
# Description

    qemuarm: Fix compilation for walnascar release.

    meta-rauc master branch changed to whinlatter release end of October
    2025. Therefore, the walnascar branch needs to be selected.
    (Use the default branch name which is set in the same file.)

# Testing done

Without the change:
```
$ run-kas build meta-rauc-community/meta-rauc-qemuarm/kas-qemuarm.yml
2026-02-02 10:34:45 - INFO     - run-kas 4.8.2 started
2026-02-02 10:34:45 - INFO     - Using /media/data/rauc-walsnacar/meta-rauc-community as root for repository meta-rauc-community
2026-02-02 10:34:45 - INFO     - Cloning repository meta-rauc
2026-02-02 10:34:45 - INFO     - Cloning repository poky
2026-02-02 10:34:46 - INFO     - Repository meta-rauc already contains master as commit
2026-02-02 10:35:02 - INFO     - Repository poky updated
2026-02-02 10:35:02 - INFO     - Repository meta-rauc checked out to d0bac6cd07b8c72b07ea806d76bcc9ec3f75969e
2026-02-02 10:35:03 - INFO     - Repository poky checked out to d0b46a6624ec9c61c47270745dd0b2d5abbe6ac1
2026-02-02 10:35:03 - INFO     - /media/data/rauc-walsnacar/build$ /media/data/rauc-walsnacar/layers/poky/bitbake/bin/bitbake -c build core-image-minimal update-bundle
ERROR: Layer rauc is not compatible with the core layer which only supports these series: walnascar (layer is compatible with whinlatter)
2026-02-02 10:35:05 - ERROR    - Command "/media/data/rauc-walsnacar/layers/poky/bitbake/bin/bitbake -c build core-image-minimal update-bundle" failed with error 1
```

With the change:

```
$ run-kas build meta-rauc-community/meta-rauc-qemuarm/kas-qemuarm.yml
2026-02-02 10:35:33 - INFO     - run-kas 4.8.2 started
2026-02-02 10:35:33 - INFO     - Using /media/data/rauc-walsnacar/meta-rauc-community as root for repository meta-rauc-community
2026-02-02 10:35:33 - INFO     - Cloning repository meta-rauc
2026-02-02 10:35:33 - INFO     - Cloning repository poky
2026-02-02 10:35:35 - INFO     - Repository meta-rauc updated
2026-02-02 10:35:52 - INFO     - Repository poky updated
2026-02-02 10:35:52 - INFO     - Repository meta-rauc checked out to a0b83842d131093e89fa4fefaaa1997f05afdf62
2026-02-02 10:35:53 - INFO     - Repository poky checked out to d0b46a6624ec9c61c47270745dd0b2d5abbe6ac1
2026-02-02 10:35:53 - INFO     - /media/data/rauc-walsnacar/build$ /media/data/rauc-walsnacar/layers/poky/bitbake/bin/bitbake -c build core-image-minimal update-bundle
Loading cache: 100% |   | ETA:  --:--:--Loaded 0 entries from dependency cache.
Parsing recipes: 100%
(...)
```
-> recipe parsing (and build) is successful