### PR TITLE
Make Layers Compatible with 'whinlatter'

### DIFF
--- a/.github/workflows/meta-rauc-beaglebone.yml
+++ b/.github/workflows/meta-rauc-beaglebone.yml
@@ -36,14 +36,19 @@ jobs:
           sudo apt-get -q -y --no-install-recommends install diffstat tree chrpath
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Clone poky
-        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
+      - name: Clone bitbake
+        run: git clone --shared --reference-if-able /srv/shared-git/bitbake.git -b master https://github.com/openembedded/bitbake.git
+      - name: Clone openembedded-core
+        run: git clone --shared --reference-if-able /srv/shared-git/openembedded-core.git -b master https://github.com/openembedded/openembedded-core.git
       - name: Clone meta-rauc
         run: git clone --shared --reference-if-able /srv/shared-git/meta-rauc.git -b master https://github.com/rauc/meta-rauc.git
+      - name: Clone meta-yocto
+        run: git clone --shared --reference-if-able /srv/shared-git/meta-yocto.git -b master https://git.yoctoproject.org/meta-yocto
       - name: Initialize build directory
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake-layers add-layer ../meta-rauc
+          bitbake-layers add-layer ../meta-yocto/meta-yocto-bsp
           bitbake-layers add-layer ../meta-rauc-beaglebone
           if [ -f ~/.yocto/auto.conf ]; then
             cp ~/.yocto/auto.conf conf/
@@ -68,19 +73,19 @@ jobs:
           rgrep . *.conf
       - name: Test bitbake parsing
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake -p
       - name: Build rauc, rauc-native
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake rauc rauc-native
       - name: Build core-image-minimal
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake core-image-minimal
       - name: Build RAUC Bundle
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake update-bundle
       - name: Cache Data
         env:

--- a/.github/workflows/meta-rauc-qemuarm.yml
+++ b/.github/workflows/meta-rauc-qemuarm.yml
@@ -36,13 +36,15 @@ jobs:
           sudo apt-get -q -y --no-install-recommends install diffstat tree chrpath
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Clone poky
-        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
+      - name: Clone bitbake
+        run: git clone --shared --reference-if-able /srv/shared-git/bitbake.git -b master https://github.com/openembedded/bitbake.git
+      - name: Clone openembedded-core
+        run: git clone --shared --reference-if-able /srv/shared-git/openembedded-core.git -b master https://github.com/openembedded/openembedded-core.git
       - name: Clone meta-rauc
         run: git clone --shared --reference-if-able /srv/shared-git/meta-rauc.git -b master https://github.com/rauc/meta-rauc.git
       - name: Initialize build directory
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake-layers add-layer ../meta-rauc
           bitbake-layers add-layer ../meta-rauc-qemuarm
           if [ -f ~/.yocto/auto.conf ]; then
@@ -67,19 +69,19 @@ jobs:
           rgrep . *.conf
       - name: Test bitbake parsing
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake -p
       - name: Build rauc, rauc-native
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake rauc rauc-native
       - name: Build core-image-minimal
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake core-image-minimal
       - name: Build RAUC Bundle
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake update-bundle
       - name: Cache Data
         env:

--- a/.github/workflows/meta-rauc-qemux86.yml
+++ b/.github/workflows/meta-rauc-qemux86.yml
@@ -36,13 +36,15 @@ jobs:
           sudo apt-get -q -y --no-install-recommends install diffstat tree chrpath
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Clone poky
-        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
+      - name: Clone bitbake
+        run: git clone --shared --reference-if-able /srv/shared-git/bitbake.git -b master https://github.com/openembedded/bitbake.git
+      - name: Clone openembedded-core
+        run: git clone --shared --reference-if-able /srv/shared-git/openembedded-core.git -b master https://github.com/openembedded/openembedded-core.git
       - name: Clone meta-rauc
         run: git clone --shared --reference-if-able /srv/shared-git/meta-rauc.git -b master https://github.com/rauc/meta-rauc.git
       - name: Initialize build directory
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake-layers add-layer ../meta-rauc
           bitbake-layers add-layer ../meta-rauc-qemux86
           if [ -f ~/.yocto/auto.conf ]; then
@@ -69,19 +71,19 @@ jobs:
           rgrep . *.conf
       - name: Test bitbake parsing
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake -p
       - name: Build rauc, rauc-native
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake rauc rauc-native
       - name: Build core-image-minimal
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake core-image-minimal
       - name: Build RAUC Bundle
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake qemu-demo-bundle
       - name: Cache Data
         env:

--- a/.github/workflows/meta-rauc-raspberrypi.yml
+++ b/.github/workflows/meta-rauc-raspberrypi.yml
@@ -36,15 +36,17 @@ jobs:
           sudo apt-get -q -y --no-install-recommends install diffstat tree chrpath
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Clone poky
-        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
+      - name: Clone bitbake
+        run: git clone --shared --reference-if-able /srv/shared-git/bitbake.git -b master https://github.com/openembedded/bitbake.git
+      - name: Clone openembedded-core
+        run: git clone --shared --reference-if-able /srv/shared-git/openembedded-core.git -b master https://github.com/openembedded/openembedded-core.git
       - name: Clone meta-rauc
         run: git clone --shared --reference-if-able /srv/shared-git/meta-rauc.git -b master https://github.com/rauc/meta-rauc.git
       - name: Clone meta-raspberrypi
         run: git clone --shared --reference-if-able /srv/shared-git/meta-raspberrypi.git -b master https://github.com/agherzan/meta-raspberrypi.git
       - name: Initialize build directory
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake-layers add-layer ../meta-rauc
           bitbake-layers add-layer ../meta-raspberrypi
           bitbake-layers add-layer ../meta-rauc-raspberrypi
@@ -70,19 +72,19 @@ jobs:
           rgrep . *.conf
       - name: Test bitbake parsing
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake -p
       - name: Build rauc, rauc-native
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake rauc rauc-native
       - name: Build core-image-minimal
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake core-image-minimal
       - name: Build RAUC Bundle
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake update-bundle
       - name: Cache Data
         env:

--- a/.github/workflows/meta-rauc-sunxi.yml
+++ b/.github/workflows/meta-rauc-sunxi.yml
@@ -36,8 +36,10 @@ jobs:
           sudo apt-get -q -y --no-install-recommends install diffstat tree chrpath
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Clone poky
-        run: git clone --shared --reference-if-able /srv/shared-git/poky.git -b master https://github.com/yoctoproject/poky.git
+      - name: Clone bitbake
+        run: git clone --shared --reference-if-able /srv/shared-git/bitbake.git -b master https://github.com/openembedded/bitbake.git
+      - name: Clone openembedded-core
+        run: git clone --shared --reference-if-able /srv/shared-git/openembedded-core.git -b master https://github.com/openembedded/openembedded-core.git
       - name: Clone meta-rauc
         run: git clone --shared --reference-if-able /srv/shared-git/meta-rauc.git -b master https://github.com/rauc/meta-rauc.git
       - name: Clone meta-arm
@@ -48,7 +50,7 @@ jobs:
         run: git clone --shared --reference-if-able /srv/shared-git/meta-sunxi.git -b master https://github.com/linux-sunxi/meta-sunxi.git
       - name: Initialize build directory
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake-layers add-layer ../meta-rauc
           bitbake-layers add-layer ../meta-arm/meta-arm-toolchain
           bitbake-layers add-layer ../meta-arm/meta-arm
@@ -81,19 +83,19 @@ jobs:
           rgrep . *.conf
       - name: Test bitbake parsing
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake -p
       - name: Build rauc, rauc-native
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake rauc rauc-native
       - name: Build core-image-minimal
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake core-image-minimal
       - name: Build RAUC Bundle
         run: |
-          source poky/oe-init-build-env build
+          source openembedded-core/oe-init-build-env build
           bitbake update-bundle
       - name: Cache Data
         env:

--- a/meta-rauc-beaglebone/README.rst
+++ b/meta-rauc-beaglebone/README.rst
@@ -6,8 +6,8 @@ Dependencies
 ============
 
 * URI: git://git.openembedded.org/openembedded-core
+* URI: https://git.yoctoproject.org/meta-yocto
 * URI: https://github.com/rauc/meta-rauc.git
-* URI: https://git.yoctoproject.org/poky/
 
 Patches
 =======

--- a/meta-rauc-beaglebone/conf/layer.conf
+++ b/meta-rauc-beaglebone/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-rauc-beaglebone = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-beaglebone = "6"
 
 LAYERDEPENDS_meta-rauc-beaglebone = "core rauc yoctobsp"
-LAYERSERIES_COMPAT_meta-rauc-beaglebone = "walnascar"
+LAYERSERIES_COMPAT_meta-rauc-beaglebone = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"

--- a/meta-rauc-beaglebone/recipes-bsp/u-boot/files/0001-am335x_evm_defconfig-rauc.patch
+++ b/meta-rauc-beaglebone/recipes-bsp/u-boot/files/0001-am335x_evm_defconfig-rauc.patch
@@ -1,4 +1,4 @@
-From c87df6a895c5a2db70890127996fb3cacc94bca7 Mon Sep 17 00:00:00 2001
+From 6b9801ec2962ddc331381d5effb61698671db2ef Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Fri, 4 Apr 2025 10:13:49 +0000
 Subject: [PATCH] am335x_evm_defconfig: RAUC
@@ -11,7 +11,7 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/configs/am335x_evm_defconfig b/configs/am335x_evm_defconfig
-index 6d1da0cfc7c..c37a8cb91ba 100644
+index 2b68902edef..ff83faaae70 100644
 --- a/configs/am335x_evm_defconfig
 +++ b/configs/am335x_evm_defconfig
 @@ -17,7 +17,7 @@ CONFIG_FIT_VERBOSE=y
@@ -22,8 +22,8 @@ index 6d1da0cfc7c..c37a8cb91ba 100644
 +CONFIG_BOOTCOMMAND="load mmc 0:1 $loadaddr boot.scr; source $loadaddr"
  CONFIG_LOGLEVEL=3
  CONFIG_SYS_CONSOLE_INFO_QUIET=y
- CONFIG_ARCH_MISC_INIT=y
-@@ -45,7 +45,7 @@ CONFIG_CMD_SPL=y
+ CONFIG_SPL_SYS_MALLOC=y
+@@ -44,7 +44,7 @@ CONFIG_CMD_SPL=y
  CONFIG_CMD_SPL_NAND_OFS=0x00080000
  CONFIG_SYS_I2C_EEPROM_ADDR_LEN=2
  CONFIG_CMD_NAND=y
@@ -40,6 +40,3 @@ index 6d1da0cfc7c..c37a8cb91ba 100644
 +CONFIG_ENV_EXT4_DEVICE_AND_PART="0:1"
 +CONFIG_ENV_EXT4_FILE="/boot/uboot.env"
 +CONFIG_LEGACY_IMAGE_FORMAT=y
--- 
-2.49.0
-

--- a/meta-rauc-nxp/conf/layer.conf
+++ b/meta-rauc-nxp/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-rauc-nxp = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-nxp = "6"
 
 LAYERDEPENDS_meta-rauc-nxp = "core rauc freescale-layer freescale-3rdparty"
-LAYERSERIES_COMPAT_meta-rauc-nxp = "styhead walnascar"
+LAYERSERIES_COMPAT_meta-rauc-nxp = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"

--- a/meta-rauc-qemuarm/kas-qemuarm.yml
+++ b/meta-rauc-qemuarm/kas-qemuarm.yml
@@ -2,11 +2,11 @@ header:
   version: 14
 
 machine: qemuarm64
-distro: poky
+distro: nodistro
 
 defaults:
   repos:
-    branch: walnascar
+    branch: master
 
 repos:
   meta-rauc-community:
@@ -16,13 +16,17 @@ repos:
     url: "https://github.com/rauc/meta-rauc.git"
     branch: master
     path: layers/meta-rauc
-  poky:
-    url: "https://git.yoctoproject.org/git/poky"
-    path: layers/poky
+  bitbake:
+    url: "https://github.com/openembedded/bitbake.git"
+    path: layers/bitbake
+    # this repo does not provide any layers
+    layers:
+      .: disabled
+  openembedded-core:
+    url: "https://github.com/openembedded/openembedded-core.git"
+    path: layers/openembedded-core
     layers:
       meta:
-      meta-poky:
-      meta-yocto-bsp:
 
 target:
   - core-image-minimal

--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "meta-rauc-qemux86"
 BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
-LAYERDEPENDS_meta-rauc-qemux86 = "core"
+LAYERDEPENDS_meta-rauc-qemux86 = "core rauc"
 LAYERSERIES_COMPAT_meta-rauc-qemux86 = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"

--- a/meta-rauc-qemux86/conf/layer.conf
+++ b/meta-rauc-qemux86/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-rauc-qemux86 = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-qemux86 = "6"
 
 LAYERDEPENDS_meta-rauc-qemux86 = "core"
-LAYERSERIES_COMPAT_meta-rauc-qemux86 = "styhead walnascar"
+LAYERSERIES_COMPAT_meta-rauc-qemux86 = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"

--- a/meta-rauc-qemux86/kas-qemu-grub.yml
+++ b/meta-rauc-qemux86/kas-qemu-grub.yml
@@ -1,27 +1,37 @@
 header:
   # We require kas config version 14
   version: 14
+
 machine: qemux86-64
-distro: poky
+distro: nodistro
+
+defaults:
+  repos:
+      branch: master
+
 repos:
   meta-rauc-community:
     layers:
       meta-rauc-qemux86:
   meta-rauc:
     url: "https://github.com/rauc/meta-rauc.git"
-    branch: master
     path: layers/meta-rauc
-  poky:
-    url: "https://git.yoctoproject.org/git/poky"
-    branch: master
-    path: layers/poky
+  bitbake:
+    url: "https://github.com/openembedded/bitbake.git"
+    path: layers/bitbake
+    # this repo does not provide any layers
+    layers:
+      .: disabled
+  openembedded-core:
+    url: "https://github.com/openembedded/openembedded-core.git"
+    path: layers/openembedded-core
     layers:
       meta:
-      meta-poky:
-      meta-yocto-bsp:
+
 target:
   - core-image-minimal
   - core-bundle-minimal
+
 local_conf_header:
   meta-custom: |
     DISTRO_FEATURES:append = " rauc"

--- a/meta-rauc-qemux86/recipes-bsp/grub/rauc-qemu-grubconf.bb
+++ b/meta-rauc-qemux86/recipes-bsp/grub/rauc-qemu-grubconf.bb
@@ -11,8 +11,7 @@ SRC_URI += " \
     file://grubenv \
     "
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 inherit deploy
 

--- a/meta-rauc-rockchip/README.rst
+++ b/meta-rauc-rockchip/README.rst
@@ -7,7 +7,6 @@ Dependencies
 
 * URI: git://git.openembedded.org/openembedded-core
 * URI: https://github.com/rauc/meta-rauc.git
-* URI: https://git.yoctoproject.org/poky/
 * URI: https://git.yoctoproject.org/meta-arm
 * URI: https://git.yoctoproject.org/meta-rockchip/
 

--- a/meta-rauc-rockchip/conf/layer.conf
+++ b/meta-rauc-rockchip/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "meta-rauc-rockchip"
 BBFILE_PATTERN_meta-rauc-rockchip = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-rockchip = "6"
 
-LAYERDEPENDS_meta-rauc-rockchip = "core"
+LAYERDEPENDS_meta-rauc-rockchip = "core rauc"
 LAYERSERIES_COMPAT_meta-rauc-rockchip = "styhead walnascar"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"

--- a/meta-rauc-sunxi/README.rst
+++ b/meta-rauc-sunxi/README.rst
@@ -5,7 +5,7 @@ Please see the corresponding sections below for details.
 Dependencies
 ============
 
-  URI: https://git.yoctoproject.org/poky
+* URI: git://git.openembedded.org/openembedded-core
   branch: styhead
 
   URI: https://github.com/rauc/meta-rauc.git

--- a/meta-rauc-sunxi/conf/layer.conf
+++ b/meta-rauc-sunxi/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "meta-rauc-sunxi"
 BBFILE_PATTERN_meta-rauc-sunxi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-sunxi = "11"
 
-LAYERDEPENDS_meta-rauc-sunxi = "core rauc"
+LAYERDEPENDS_meta-rauc-sunxi = "core rauc sunxi"
 LAYERSERIES_COMPAT_meta-rauc-sunxi = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"

--- a/meta-rauc-sunxi/conf/layer.conf
+++ b/meta-rauc-sunxi/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-rauc-sunxi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-sunxi = "11"
 
 LAYERDEPENDS_meta-rauc-sunxi = "core"
-LAYERSERIES_COMPAT_meta-rauc-sunxi = "styhead walnascar"
+LAYERSERIES_COMPAT_meta-rauc-sunxi = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"
 RAUC_CERT_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.cert.pem"

--- a/meta-rauc-sunxi/conf/layer.conf
+++ b/meta-rauc-sunxi/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "meta-rauc-sunxi"
 BBFILE_PATTERN_meta-rauc-sunxi = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-rauc-sunxi = "11"
 
-LAYERDEPENDS_meta-rauc-sunxi = "core"
+LAYERDEPENDS_meta-rauc-sunxi = "core rauc"
 LAYERSERIES_COMPAT_meta-rauc-sunxi = "whinlatter"
 
 RAUC_KEY_FILE ?= "${LAYERDIR}/../files/rauc-example-keys/development-1.key.pem"

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0001-A10-OLinuXino-Lime_defconfig-RAUC.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0001-A10-OLinuXino-Lime_defconfig-RAUC.patch
@@ -1,4 +1,4 @@
-From 10b67c04ec8c8bf7f74292da227812a8cbd48420 Mon Sep 17 00:00:00 2001
+From 0f407063b9a94fa39bb5fe195e86e9b218c39318 Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Fri, 16 Aug 2024 12:34:41 +0000
 Subject: [PATCH] A10-OLinuXino-Lime_defconfig: RAUC
@@ -11,7 +11,7 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/configs/A10-OLinuXino-Lime_defconfig b/configs/A10-OLinuXino-Lime_defconfig
-index 57e91d0f01..59e5e87fd2 100644
+index 96e3d19038b..fb5b10d1343 100644
 --- a/configs/A10-OLinuXino-Lime_defconfig
 +++ b/configs/A10-OLinuXino-Lime_defconfig
 @@ -22,3 +22,6 @@ CONFIG_AXP_ALDO4_VOLT=2800
@@ -21,6 +21,3 @@ index 57e91d0f01..59e5e87fd2 100644
 +CONFIG_ENV_SIZE=0x20000
 +CONFIG_ENV_OFFSET=0x0000
 +CONFIG_ENV_IS_IN_FAT=y
--- 
-2.44.1
-

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0002-orangepi_one_defconfig-RAUC.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0002-orangepi_one_defconfig-RAUC.patch
@@ -1,4 +1,4 @@
-From f3204a8c856a676cd25e7f2ba2459d8013da8450 Mon Sep 17 00:00:00 2001
+From 74d034ba23aeba040be81f5d1d866324d1173dc1 Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Mon, 19 Aug 2024 12:58:40 +0000
 Subject: [PATCH] orangepi_one_defconfig: RAUC
@@ -15,7 +15,7 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/configs/orangepi_one_defconfig b/configs/orangepi_one_defconfig
-index 1064b4a39d..c11c151e10 100644
+index 1064b4a39de..c11c151e10e 100644
 --- a/configs/orangepi_one_defconfig
 +++ b/configs/orangepi_one_defconfig
 @@ -8,3 +8,6 @@ CONFIG_DRAM_CLK=672
@@ -25,6 +25,3 @@ index 1064b4a39d..c11c151e10 100644
 +CONFIG_ENV_SIZE=0x20000
 +CONFIG_ENV_OFFSET=0x0000
 +CONFIG_ENV_IS_IN_FAT=y
--- 
-2.45.2
-

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0003-orangepi_zero_defconfig-RAUC.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0003-orangepi_zero_defconfig-RAUC.patch
@@ -1,4 +1,4 @@
-From 45ceaf931176949f6d1fe7fbd8ff870e5bdb72a2 Mon Sep 17 00:00:00 2001
+From ccd55e301254999cc6881a4bc3efeea6171ac6ef Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Mon, 19 Aug 2024 13:41:38 +0000
 Subject: [PATCH] orangepi_zero_defconfig: RAUC
@@ -15,7 +15,7 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/configs/orangepi_zero_defconfig b/configs/orangepi_zero_defconfig
-index abdf9a9396..3eb721cd1b 100644
+index abdf9a93966..3eb721cd1b1 100644
 --- a/configs/orangepi_zero_defconfig
 +++ b/configs/orangepi_zero_defconfig
 @@ -15,3 +15,6 @@ CONFIG_SUN8I_EMAC=y
@@ -25,6 +25,3 @@ index abdf9a9396..3eb721cd1b 100644
 +CONFIG_ENV_SIZE=0x20000
 +CONFIG_ENV_OFFSET=0x0000
 +CONFIG_ENV_IS_IN_FAT=y
--- 
-2.45.2
-

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0004-configs-A20-OLinuXino_MICRO_defconfig-RAUC.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0004-configs-A20-OLinuXino_MICRO_defconfig-RAUC.patch
@@ -1,4 +1,4 @@
-From 0d7284e52817c5138050ac12070369663064c1ea Mon Sep 17 00:00:00 2001
+From c16b55decca368fdcc1010b4df7e358a6b15ebe3 Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Mon, 19 Aug 2024 16:33:44 +0000
 Subject: [PATCH] configs/A20-OLinuXino_MICRO_defconfig: RAUC
@@ -15,7 +15,7 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  1 file changed, 4 insertions(+)
 
 diff --git a/configs/A20-OLinuXino_MICRO_defconfig b/configs/A20-OLinuXino_MICRO_defconfig
-index 2d7532d9a2..2dc54ba399 100644
+index 2d7532d9a2f..2dc54ba3993 100644
 --- a/configs/A20-OLinuXino_MICRO_defconfig
 +++ b/configs/A20-OLinuXino_MICRO_defconfig
 @@ -21,8 +21,12 @@ CONFIG_MII=y
@@ -31,6 +31,3 @@ index 2d7532d9a2..2dc54ba399 100644
 +CONFIG_ENV_SIZE=0x20000
 +CONFIG_ENV_OFFSET=0x0000
 +CONFIG_ENV_IS_IN_FAT=y
--- 
-2.45.2
-

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0005-configs-Merrii_A80_Optimus_defconfig-RAUC.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0005-configs-Merrii_A80_Optimus_defconfig-RAUC.patch
@@ -1,4 +1,4 @@
-From bb8df05b0463e1c0d58813380458a8c59ffad576 Mon Sep 17 00:00:00 2001
+From ebaa42fe09825f86e1eaa30fdf947a702a09ff84 Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Tue, 10 Dec 2024 10:00:20 +0000
 Subject: [PATCH] configs/Merrii_A80_Optimus_defconfig: RAUC
@@ -15,16 +15,13 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/configs/Merrii_A80_Optimus_defconfig b/configs/Merrii_A80_Optimus_defconfig
-index a26677e1c0..9c79d7aeab 100644
+index 1bfbeec1d02..c000d614b42 100644
 --- a/configs/Merrii_A80_Optimus_defconfig
 +++ b/configs/Merrii_A80_Optimus_defconfig
-@@ -13,3 +13,6 @@ CONFIG_AXP_GPIO=y
- CONFIG_SYS_I2C_SUN8I_RSB=y
+@@ -10,3 +10,6 @@ CONFIG_SYS_I2C_SUN8I_RSB=y
+ CONFIG_REGULATOR_AXP_DRIVEVBUS=y
  CONFIG_REGULATOR_AXP_USB_POWER=y
  CONFIG_AXP809_POWER=y
 +CONFIG_ENV_SIZE=0x20000
 +CONFIG_ENV_OFFSET=0x0000
 +CONFIG_ENV_IS_IN_FAT=y
--- 
-2.47.0
-

--- a/meta-rauc-sunxi/recipes-bsp/u-boot/files/0006-Add-support-for-Cubieboard-4-board-with-Allwinner-80.patch
+++ b/meta-rauc-sunxi/recipes-bsp/u-boot/files/0006-Add-support-for-Cubieboard-4-board-with-Allwinner-80.patch
@@ -1,4 +1,4 @@
-From 093b6d79694fde0656f97fe6eacf331d9109f028 Mon Sep 17 00:00:00 2001
+From 8c94971743f38d7cd8bac08c61d73cb988797b85 Mon Sep 17 00:00:00 2001
 From: lazarh <def_58@abv.bg>
 Date: Tue, 10 Dec 2024 16:56:05 +0000
 Subject: [PATCH] Add support for Cubieboard 4 board with Allwinner 80 SoC from
@@ -16,16 +16,13 @@ Signed-off-by: Lazar Hristov <lhristov@gmail.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/configs/Cubieboard4_defconfig b/configs/Cubieboard4_defconfig
-index d3678ad5c7..2a4accb372 100644
+index 33937abfb22..b72941c60c3 100644
 --- a/configs/Cubieboard4_defconfig
 +++ b/configs/Cubieboard4_defconfig
-@@ -13,3 +13,6 @@ CONFIG_AXP_GPIO=y
- CONFIG_SYS_I2C_SUN8I_RSB=y
+@@ -10,3 +10,6 @@ CONFIG_SYS_I2C_SUN8I_RSB=y
+ CONFIG_REGULATOR_AXP_DRIVEVBUS=y
  CONFIG_REGULATOR_AXP_USB_POWER=y
  CONFIG_AXP809_POWER=y
 +CONFIG_ENV_SIZE=0x20000
 +CONFIG_ENV_OFFSET=0x0000
 +CONFIG_ENV_IS_IN_FAT=y
--- 
-2.47.0
-


### PR DESCRIPTION
The poky master branch is no longer being updated and was replaced by a README. There is a mail by Richard Purdie describing this change and the motivation behind it[1].

For us this means cloning the bitbake and oe-core repositories separately instead of using the combined poky repo.

[1]: https://lists.openembedded.org/g/openembedded-architecture/message/2179