### PR TITLE
integrate "bootchooser: add Raspberry Pi firmware"

### DIFF
--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -49,7 +49,6 @@ Add configuration required for meta-raspberrypi to your local.conf::
 
    # Generic raspberrypi settings
    ENABLE_UART = "1"
-   RPI_USE_U_BOOT = "1"
 
 Set the ``MACHINE`` to the model you intend to build for. E.g.::
 
@@ -63,6 +62,8 @@ Add configuration required for meta-rauc-raspberrypi to your local.conf::
 
    # Settings for meta-rauc-raspberry-pi
    IMAGE_INSTALL:append = " rauc"
+   IMAGE_INSTALL:append = " rpi-eeprom"
+   IMAGE_INSTALL:append = " rpi-autoboot"
    IMAGE_FSTYPES:append = " ext4"
    WKS_FILE = "sdimage-dual-raspberrypi.wks.in"
 

--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -64,8 +64,10 @@ Add configuration required for meta-rauc-raspberrypi to your local.conf::
    IMAGE_INSTALL:append = " rauc"
    IMAGE_INSTALL:append = " rpi-eeprom"
    IMAGE_INSTALL:append = " rpi-autoboot"
+   IMAGE_FSTYPES:remove = " ext3"
    IMAGE_FSTYPES:append = " ext4"
    WKS_FILE = "sdimage-dual-raspberrypi.wks.in"
+   WIC_CREATE_EXTRA_ARGS = " --no-fstab-update"
 
 Make sure either your distro (recommended) or your local.conf have ``rauc``
 ``DISTRO_FEATURE`` enabled::

--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -111,3 +111,29 @@ Copy the generated bundle to the target system via nc, scp or an attached USB st
 On the target, you can then install the bundle::
 
   # rauc install /path/to/bundle.raucb
+
+V. Known Issues & Troubleshooting
+==================================
+
+EEPROM/Bootloader Version Requirement (RPi 4 / RPi 5)
+------------------------------------------------------
+
+The Raspberry Pi ``tryboot`` mechanism used for A/B slot switching requires a
+sufficiently recent EEPROM bootloader. Very old bootloader versions (e.g. from
+2021) are known to fail when setting the ``tryboot`` bit. Versions from 2023
+onwards appear to work.
+
+Since ``rpi-eeprom-update`` is only available on Raspberry Pi OS (Raspbian),
+updating the EEPROM must be done **before** flashing the Yocto image:
+
+1. Boot a vanilla Raspberry Pi OS on the device.
+2. Check the current bootloader version::
+
+     $ rpi-eeprom-update
+
+3. If the output shows ``UPDATE AVAILABLE``, install it::
+
+     $ sudo rpi-eeprom-update -a
+     $ sudo reboot
+
+4. After the reboot, flash and boot the Yocto image as described above.

--- a/meta-rauc-raspberrypi/README.rst
+++ b/meta-rauc-raspberrypi/README.rst
@@ -123,6 +123,11 @@ sufficiently recent EEPROM bootloader. Very old bootloader versions (e.g. from
 2021) are known to fail when setting the ``tryboot`` bit. Versions from 2023
 onwards appear to work.
 
+The bootloader versions and their fixes are tracked in the Raspberry Pi
+``rpi-eeprom`` `release notes
+<https://github.com/raspberrypi/rpi-eeprom/blob/master/firmware-2711/release-notes.md>`_
+(repository and issue tracker: https://github.com/raspberrypi/rpi-eeprom).
+
 Since ``rpi-eeprom-update`` is only available on Raspberry Pi OS (Raspbian),
 updating the EEPROM must be done **before** flashing the Yocto image:
 

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -5,8 +5,8 @@ CMDLINE_ROOTFS = ""
 
 # Provide A/B specific cmdline files to be used with [boot_partition=N] filter
 do_compile:append () {
-    echo "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p2:/boot:vfat" > "${WORKDIR}/cmdline-rootfs-A.txt"
-    echo "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p3:/boot:vfat" > "${WORKDIR}/cmdline-rootfs-B.txt"
+    echo "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p2:/boot:vfat rauc.slot=firmware.0" > "${WORKDIR}/cmdline-rootfs-A.txt"
+    echo "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p3:/boot:vfat rauc.slot=firmware.1" > "${WORKDIR}/cmdline-rootfs-B.txt"
 }
 
 do_deploy:append() {

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -5,8 +5,8 @@ CMDLINE_ROOTFS = ""
 
 # Provide A/B specific cmdline files to be used with [boot_partition=N] filter
 do_compile:append () {
-    echo "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait" > "${WORKDIR}/cmdline-rootfs-A.txt"
-    echo "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait" > "${WORKDIR}/cmdline-rootfs-B.txt"
+    echo "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p2:/boot:vfat" > "${WORKDIR}/cmdline-rootfs-A.txt"
+    echo "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p3:/boot:vfat" > "${WORKDIR}/cmdline-rootfs-B.txt"
 }
 
 do_deploy:append() {

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# Will be set from the A/B specific cmdline_*.txt files instead
+CMDLINE_ROOTFS = ""
+
+# Provide A/B specific cmdline files to be used with [boot_partition=N] filter
+do_compile:append () {
+    echo "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait" > "${WORKDIR}/cmdline-rootfs-A.txt"
+    echo "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait" > "${WORKDIR}/cmdline-rootfs-B.txt"
+}
+
+do_deploy:append() {
+    install -m 0644 "${WORKDIR}/cmdline-rootfs-A.txt" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
+    install -m 0644 "${WORKDIR}/cmdline-rootfs-B.txt" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
+}

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,12 +1,21 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-# Will be set from the A/B specific cmdline_*.txt files instead
+# The default single cmdline.txt is unused: the RPi firmware selects a per-slot
+# cmdline via the [boot_partition=N] filter in config.txt (see rpi-config
+# bbappend), so leave CMDLINE_ROOTFS empty here; the per-slot root bits are
+# appended to the full CMDLINE below.
 CMDLINE_ROOTFS = ""
 
-# Provide A/B specific cmdline files to be used with [boot_partition=N] filter
+# Per-slot root/boot command-line bits, appended to the full CMDLINE. Partition
+# indexes depend on the image layout, so override these per-machine/image.
+CMDLINE_ROOTFS_A ?= "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p2:/boot:vfat rauc.slot=firmware.0"
+CMDLINE_ROOTFS_B ?= "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p3:/boot:vfat rauc.slot=firmware.1"
+
+# Build the per-slot cmdline files from the FULL CMDLINE (so console=,
+# net.ifnames=, CMA, dwc_otg, etc. are preserved) plus the per-slot root bits.
 do_compile:append () {
-    echo "root=/dev/mmcblk0p5 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p2:/boot:vfat rauc.slot=firmware.0" > "${WORKDIR}/cmdline-rootfs-A.txt"
-    echo "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait systemd.mount-extra=/dev/mmcblk0p3:/boot:vfat rauc.slot=firmware.1" > "${WORKDIR}/cmdline-rootfs-B.txt"
+    echo "${@' '.join(d.getVar('CMDLINE').split())} ${CMDLINE_ROOTFS_A}" > "${WORKDIR}/cmdline-rootfs-A.txt"
+    echo "${@' '.join(d.getVar('CMDLINE').split())} ${CMDLINE_ROOTFS_B}" > "${WORKDIR}/cmdline-rootfs-B.txt"
 }
 
 do_deploy:append() {

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -13,12 +13,14 @@ CMDLINE_ROOTFS_B ?= "root=/dev/mmcblk0p6 ${CMDLINE_ROOT_FSTYPE} rootwait systemd
 
 # Build the per-slot cmdline files from the FULL CMDLINE (so console=,
 # net.ifnames=, CMA, dwc_otg, etc. are preserved) plus the per-slot root bits.
+# Files are named after the config.txt [boot_partition=N] filter
+# (2 -> slot A, 3 -> slot B).
 do_compile:append () {
-    echo "${@' '.join(d.getVar('CMDLINE').split())} ${CMDLINE_ROOTFS_A}" > "${WORKDIR}/cmdline-rootfs-A.txt"
-    echo "${@' '.join(d.getVar('CMDLINE').split())} ${CMDLINE_ROOTFS_B}" > "${WORKDIR}/cmdline-rootfs-B.txt"
+    echo "${@' '.join(d.getVar('CMDLINE').split())} ${CMDLINE_ROOTFS_A}" > "${WORKDIR}/cmdline-2.txt"
+    echo "${@' '.join(d.getVar('CMDLINE').split())} ${CMDLINE_ROOTFS_B}" > "${WORKDIR}/cmdline-3.txt"
 }
 
 do_deploy:append() {
-    install -m 0644 "${WORKDIR}/cmdline-rootfs-A.txt" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
-    install -m 0644 "${WORKDIR}/cmdline-rootfs-B.txt" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
+    install -m 0644 "${WORKDIR}/cmdline-2.txt" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
+    install -m 0644 "${WORKDIR}/cmdline-3.txt" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}"
 }

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# see https://www.raspberrypi.com/documentation/computers/config_txt.html#the-boot_partitionn-filter
+RPI_EXTRA_CONFIG = "\n\
+[boot_partition=2]\n\
+cmdline=cmdline-rootfs-A.txt\n\
+\n\
+[boot_partition=3]\n\
+cmdline=cmdline-rootfs-B.txt\n\
+"

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-# see https://www.raspberrypi.com/documentation/computers/config_txt.html#the-boot_partitionn-filter
+# see https://www.raspberrypi.com/documentation/computers/config_txt.html#boot_partition-2
 RPI_EXTRA_CONFIG = "\n\
 [boot_partition=2]\n\
 cmdline=cmdline-rootfs-A.txt\n\

--- a/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-bsp/bootfiles/rpi-config_%.bbappend
@@ -3,8 +3,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 # see https://www.raspberrypi.com/documentation/computers/config_txt.html#boot_partition-2
 RPI_EXTRA_CONFIG = "\n\
 [boot_partition=2]\n\
-cmdline=cmdline-rootfs-A.txt\n\
+cmdline=cmdline-2.txt\n\
 \n\
 [boot_partition=3]\n\
-cmdline=cmdline-rootfs-B.txt\n\
+cmdline=cmdline-3.txt\n\
 "

--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-autoboot/rpi-autoboot.bb
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-autoboot/rpi-autoboot.bb
@@ -1,0 +1,15 @@
+SUMMARY = "autoboot.txt for ROM loader A/B boot"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://autoboot.txt"
+
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+
+do_install () {
+    install -d ${D}/autoboot
+    install -m 0644 ${UNPACKDIR}/autoboot.txt ${D}/autoboot/autoboot.txt
+}
+
+FILES:${PN} = "/autoboot"

--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-autoboot/rpi-autoboot.bb
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-autoboot/rpi-autoboot.bb
@@ -4,9 +4,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "file://autoboot.txt"
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
-
 do_install () {
     install -d ${D}/autoboot
     install -m 0644 ${UNPACKDIR}/autoboot.txt ${D}/autoboot/autoboot.txt

--- a/meta-rauc-raspberrypi/recipes-bsp/rpi-autoboot/rpi-autoboot/autoboot.txt
+++ b/meta-rauc-raspberrypi/recipes-bsp/rpi-autoboot/rpi-autoboot/autoboot.txt
@@ -1,0 +1,5 @@
+[all]
+tryboot_a_b=1
+boot_partition=2
+[tryboot]
+boot_partition=3

--- a/meta-rauc-raspberrypi/recipes-core/base-files/files/fstab
+++ b/meta-rauc-raspberrypi/recipes-core/base-files/files/fstab
@@ -9,6 +9,7 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 # uncomment this if your device has a SD/MMC/Transflash slot
 #/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
 
-/dev/mmcblk0p1  /boot   vfat    defaults         0       0
-/dev/mmcblk0p5  /data   ext4    defaults         0       0
-/dev/mmcblk0p6  /home   ext4    x-systemd.growfs 0       0
+/dev/mmcblk0p1  /autoboot   vfat    defaults         0       0
+# /boot and /root are dynamically mounted
+/dev/mmcblk0p7  /data   ext4    defaults         0       0
+/dev/mmcblk0p8  /home   ext4    x-systemd.growfs 0       0

--- a/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
@@ -8,6 +8,10 @@ RAUC_BUNDLE_DESCRIPTION = "RAUC Demo Bundle"
 
 RAUC_BUNDLE_FORMAT = "verity"
 
-RAUC_BUNDLE_SLOTS = "rootfs"
+RAUC_BUNDLE_SLOTS = "firmware rootfs"
+
+RAUC_SLOT_firmware = "core-image-minimal"
+RAUC_SLOT_firmware[fstype] = "ext4"
+
 RAUC_SLOT_rootfs = "core-image-minimal"
 RAUC_SLOT_rootfs[fstype] = "ext4"

--- a/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
@@ -11,7 +11,11 @@ RAUC_BUNDLE_FORMAT = "verity"
 RAUC_BUNDLE_SLOTS = "firmware rootfs"
 
 RAUC_SLOT_firmware = "core-image-minimal"
+RAUC_SLOT_firmware[file] = "core-image-minimal-${MACHINE}.rootfs-p2.img"
 RAUC_SLOT_firmware[fstype] = "ext4"
+RAUC_SLOT_firmware[rename] = "firmware.vfat"
 
 RAUC_SLOT_rootfs = "core-image-minimal"
+RAUC_SLOT_rootfs[file] = "core-image-minimal-${MACHINE}.rootfs-p5.img"
 RAUC_SLOT_rootfs[fstype] = "ext4"
+RAUC_SLOT_rootfs[rename] = "rootfs.ext4"

--- a/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-raspberrypi/recipes-core/bundles/update-bundle.bb
@@ -16,6 +16,6 @@ RAUC_SLOT_firmware[fstype] = "ext4"
 RAUC_SLOT_firmware[rename] = "firmware.vfat"
 
 RAUC_SLOT_rootfs = "core-image-minimal"
-RAUC_SLOT_rootfs[file] = "core-image-minimal-${MACHINE}.rootfs-p5.img"
+RAUC_SLOT_rootfs[file] = "core-image-minimal-${MACHINE}.rootfs.ext4"
 RAUC_SLOT_rootfs[fstype] = "ext4"
 RAUC_SLOT_rootfs[rename] = "rootfs.ext4"

--- a/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
@@ -3,3 +3,23 @@ IMAGE_INSTALL:append = " kernel-image kernel-modules"
 
 # Remove the kernel from the /boot partition because it is in rootfs
 RPI_EXTRA_IMAGE_BOOT_FILES:remove = "${KERNEL_IMAGETYPE}"
+
+IMAGE_INSTALL:append = " rpi-eeprom"
+IMAGE_INSTALL:append = " rpi-autoboot"
+IMAGE_FSTYPES:remove = " ext3"
+IMAGE_FSTYPES:append = " ext4"
+
+WKS_FILE = "sdimage-dual-raspberrypi.wks.in"
+
+# the root/boot partitions are passed in as kernel-cmdline parameters
+WIC_CREATE_EXTRA_ARGS = " --no-fstab-update"
+
+# for the bundle to have the slot images available, we need to have wic also deploy the separate partition images
+# see: https://github.com/gportay/meta-downstream/blob/master/meta-rauc-raspberrypi-firmware/recipes-core/images/core-image-minimal.bbappend
+IMAGE_CMD:wic:append() {
+    basename="$(basename "${wks%.wks}")"
+    cp "$build_wic/$basename-"*".direct.p2" "$out-p2.img"
+    ln -sf ${IMAGE_NAME}-p2.img "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}-p2.img"
+    cp "$build_wic/$basename-"*".direct.p5" "$out-p5.img"
+    ln -sf ${IMAGE_NAME}-p5.img "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}-p5.img"
+}

--- a/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/images/core-image-minimal.bbappend
@@ -14,12 +14,18 @@ WKS_FILE = "sdimage-dual-raspberrypi.wks.in"
 # the root/boot partitions are passed in as kernel-cmdline parameters
 WIC_CREATE_EXTRA_ARGS = " --no-fstab-update"
 
-# for the bundle to have the slot images available, we need to have wic also deploy the separate partition images
+# Expose wic partition images as RAUC slot sources (the bundle picks the ones it
+# names).
+# Note: a blanket "deploy every partition" loop is avoided on purpose
+# - the rootfs A/B partitions are fixed-size (multiple GB), and the
+# rootfs slot is bundled from the content-sized .ext4, so only the
+# partitions the bundle actually references are deployed.
 # see: https://github.com/gportay/meta-downstream/blob/master/meta-rauc-raspberrypi-firmware/recipes-core/images/core-image-minimal.bbappend
+WIC_DEPLOY_PARTITION_IMAGES ?= "p2 p5"
 IMAGE_CMD:wic:append() {
     basename="$(basename "${wks%.wks}")"
-    cp "$build_wic/$basename-"*".direct.p2" "$out-p2.img"
-    ln -sf ${IMAGE_NAME}-p2.img "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}-p2.img"
-    cp "$build_wic/$basename-"*".direct.p5" "$out-p5.img"
-    ln -sf ${IMAGE_NAME}-p5.img "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}-p5.img"
+    for pnum in ${WIC_DEPLOY_PARTITION_IMAGES}; do
+        cp "$build_wic/$basename-"*".direct.$pnum" "$out-$pnum.img"
+        ln -sf "${IMAGE_NAME}-$pnum.img" "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}-$pnum.img"
+    done
 }

--- a/meta-rauc-raspberrypi/recipes-core/rauc/files/system.conf
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/files/system.conf
@@ -1,17 +1,27 @@
 [system]
 compatible=@@MACHINE@@
-bootloader=uboot
+bootloader=raspberrypi
 data-directory=/data/
 
 [keyring]
 path=/etc/rauc/ca.cert.pem
  
-[slot.rootfs.0]
+[slot.firmware.0]
 device=/dev/mmcblk0p2
+type=vfat
+bootname=2
+
+[slot.firmware.1]
+device=/dev/mmcblk0p3
+type=vfat
+bootname=3
+
+[slot.rootfs.0]
+device=/dev/mmcblk0p5
 type=ext4
-bootname=A
+parent=firmware.0
 
 [slot.rootfs.1]
-device=/dev/mmcblk0p3
+device=/dev/mmcblk0p6
 type=ext4
-bootname=B
+parent=firmware.1

--- a/meta-rauc-raspberrypi/recipes-core/rauc/files/system.conf
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/files/system.conf
@@ -1,11 +1,12 @@
 [system]
 compatible=@@MACHINE@@
 bootloader=raspberrypi
-data-directory=/data/
+data-directory=/data/rauc/
+raspberrypi-autoboot-txt=/autoboot/autoboot.txt
 
 [keyring]
 path=/etc/rauc/ca.cert.pem
- 
+
 [slot.firmware.0]
 device=/dev/mmcblk0p2
 type=vfat

--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
@@ -4,7 +4,8 @@ SRC_URI:append := "  \
 "
 
 # additional dependencies required to run RAUC on the target
-RDEPENDS:${PN} += "u-boot-fw-utils u-boot-env"
+#RDEPENDS:${PN} += "u-boot-fw-utils u-boot-env"
+RDEPENDS:${PN} += "raspi-utils"
 
 inherit systemd
 

--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
@@ -1,3 +1,9 @@
+# hack... hack...
+# to get the new "bootloader=raspberrypi"
+SRC_URI = "git://github.com/Rtone/rauc.git;protocol=https;branch=bootchooser-add-raspberrypi-firmware-initial-support"
+SRCREV = "fdc22a44866b59eaee8fe830655c16a557b63f79"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4bf661c1e3793e55c8d1051bc5e0ae21"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append := "  \
 	file://rauc-grow-data-partition.service \

--- a/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-raspberrypi/recipes-core/rauc/rauc_%.bbappend
@@ -1,7 +1,7 @@
 # hack... hack...
 # to get the new "bootloader=raspberrypi"
 SRC_URI = "git://github.com/Rtone/rauc.git;protocol=https;branch=bootchooser-add-raspberrypi-firmware-initial-support"
-SRCREV = "fdc22a44866b59eaee8fe830655c16a557b63f79"
+SRCREV = "f6b5f54bb717cf8d38a6c4ff82159e7b1e655d61"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4bf661c1e3793e55c8d1051bc5e0ae21"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"

--- a/meta-rauc-raspberrypi/wic/sdimage-dual-raspberrypi.wks.in
+++ b/meta-rauc-raspberrypi/wic/sdimage-dual-raspberrypi.wks.in
@@ -1,7 +1,17 @@
-part /autoboot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/autoboot --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 10
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label kernel_A --align 4096 --size 100
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label kernel_B --align 4096 --size 100
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_A --align 4096
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_B --align 4096
+# short-description: Create Raspberry Pi SD card image
+# long-description: Creates a partitioned SD card image for use with
+#
+# Raspberry Pi:
+# /autoboot [boot]: A/B selector for the raspberry pi firmware
+# /boot [kernel_A, kernel_B]: Boot files are located in the first vfat partition.
+# / [rootfs_A, rootfs_B]: RootFS is located in the second ext4 partition.
+# /data [data]: common partition for RAUC state etc
+# /home [homefs]: common partition for the user home directory, set to fill the available space on the emmc
+
+part /autoboot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/autoboot --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --fixed-size 10
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label kernel_A --align 4096 --fixed-size 100
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label kernel_B --align 4096 --fixed-size 100
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_A --align 4096 --fixed-size 3584
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_B --align 4096 --fixed-size 3584
 part /data --fixed-size 100M --ondisk mmcblk0 --fstype=ext4 --label data --align 4096
 part /home --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/home --ondisk mmcblk0 --fstype=ext4 --label homefs --align 1024 --size 500 --fsoptions "x-systemd.growfs"

--- a/meta-rauc-raspberrypi/wic/sdimage-dual-raspberrypi.wks.in
+++ b/meta-rauc-raspberrypi/wic/sdimage-dual-raspberrypi.wks.in
@@ -1,4 +1,6 @@
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 100
+part /autoboot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/autoboot --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 10
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label kernel_A --align 4096 --size 100
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label kernel_B --align 4096 --size 100
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_A --align 4096
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootfs_B --align 4096
 part /data --fixed-size 100M --ondisk mmcblk0 --fstype=ext4 --label data --align 4096


### PR DESCRIPTION
Draft PR that integrates https://github.com/rauc/rauc/pull/1599
picking up [Enricos work from here](https://github.com/ejoerns/meta-rauc-community/tree/rpi-native-loader)

Of note (we should document this where?):
on RPI4 (and probably 5) setting the `tryboot` bit would fail, if the eeprom/bootloader was not on a recent enough version.
The fix is to boot a vanilla raspbian and do 
> Run "sudo rpi-eeprom-update -a" to install this update now.

<details>

```
root@testgate-c9bd34:~# rpi-eeprom-update 
*** UPDATE AVAILABLE ***
 
BOOTLOADER: update available
   CURRENT: Thu Apr 29 16:11:25 UTC 2021 (1619712685)
    LATEST: Tue Feb 11 17:00:13 UTC 2025 (1739293213)
```
the "2021" version is too old

```
BOOTLOADER: update available
   CURRENT: Wed Jan 11 17:40:52 UTC 2023 (1673458852)
    LATEST: Tue Feb 11 17:00:13 UTC 2025 (1739293213)
```
"2023" was ok(?)

</details>

A workaround is to reboot after an update with `reboot "0 tryboot"` as [documented here](https://www.raspberrypi.com/documentation/computers/config_txt.html#autoboot-txt)


Btw: we already have a couple of devices running with that (-: