### PR TITLE
meta-rauc-nxp: added support for the FRDM i.MX 93 development board

### DIFF
--- a/meta-rauc-nxp/README.frdm-imx93.rst
+++ b/meta-rauc-nxp/README.frdm-imx93.rst
@@ -1,0 +1,72 @@
+This README file has specific instructions for the NXP FRDM-IMX93 development board.
+It is separated from the other README, to allow for more specific instructions, and overrides, that can be useful for demonstrating additional RAUC constructs.
+The author has separated the effort to avoid touching the previous authors architecture, and he would be glad to rearchitect the layer.
+
+The file only specifies things that are not already specified in the README.rst file, and keeps the section numbers identical to those in that file,
+making the gaps here intentional.
+We use the exact same instructions and style. Obviously, you would better add what you need in your respective distro file, and not in local.conf.
+
+The main construct added in this example is a dual (A/B) boot/rootfs partition update scheme, where the disk layout is as follows:
+
+* p1 - BOOT_A
+* p2 - BOOT_B
+* p3 - RES (e.g., for rescue or recovery image)
+* p5 - ROOTFS_A
+* p6 - ROOTFS_B
+* p7 - DATA
+
+This of course means another kickstart file needs to be implemented, but it also means, that another image class, for getting the required boot files (i.e. what U-Boot expects
+to be on a vfat partition) needs to be implemented, so we can populate it and add it to the ``IMAGE_FSTYPES``.
+
+We will introduce a new ``DISTRO_FEATURE``, with the amazing (sorry not sorry) name ``rauc-ab-bootrootfs`` and add all of the above only if it exists, by adding it to the overrides.
+This way, the existing recipe code will remain untouched (I would separate it, but I can't test it, and I just wanted to give this example).
+
+**Note** The implementation could be more elegant if we just used another layer or did not bother about the one boot/2rootfs scheme that is in the overall meta-rauc-community repo.
+However, to keep things simple for comparison, I made the extra effort to have the previous behavior (one boot, 2 rootfs partitions) the default one.
+In the dual boot/rootfs solution (i.e. the ``rauc-ab-bootrootfs`` override), everything is identical except for the partition scheme with the following exceptions:
+* No autogrowing the data partition - and renaming the relevant recipe to a common include. Otherwise more work needs to be done
+* Less hardcoding otherwise
+* U-Boot is fully aware of which device it is running from, and not hardcoded to the sdcard.
+    * This can and should be done for the rest of the components - but to keep it very similar to the previous version prior to introducing this feature, the sdcard is assumed.
+      This is the first thing I would change if I have time, and it may happen soon enough (hopefully soon enough so you don't even see this line)
+
+
+II. Build NXP Demo System
+===============================================
+
+For FRDM-IMX93 set in local.conf::
+
+    MACHINE = "imx93frdm"
+    INIT_MANAGER = "systemd"
+    ACCEPT_FSL_EULA = "1"
+
+    #----------------------------------------------
+    # RAUC example. It is strongly recommended to
+    # not put these things in your local.conf
+    # (it is however good for explanations)
+    #----------------------------------------------
+    # Add RAUC support
+    DISTRO_FEATURES:append = " rauc"
+    IMAGE_FSTYPES:append = " ext4"
+    IMAGE_BOOT_FILES:append = " boot.scr"
+    WKS_FILE:imx93frdm = "dual-imx-boot-bootpart.wks.in"
+
+    # Allow selection of the bundle rather than hardcoding it
+    BUNDLE_IMAGE_NAME ?= "core-image-base"
+
+    # Add RAUC support for a dual boot, dual rootfs partition scheme
+    # First let's add a little cheatcode: make up a little machine override, so that we son't need to use bb.utils.contains more than this time
+    MACHINEOVERRIDES:append:imx93frdm = "${@bb.utils.contains('DISTRO_FEATURES', 'rauc-ab-bootrootfs', ':rauc-ab-bootrootfs', '', d)}"
+    DISTRO_FEATURES:append = " rauc-ab-bootrootfs"
+    BOOT_PARTITION_SIZE_MIB:rauc-ab-bootrootfs = "64"
+    RES_PARTITION_SIZE_MIB:rauc-ab-bootrootfs = "10"
+    DATA_PARTITION_SIZE_MIB:rauc-ab-bootrootfs = "100"
+    IMAGE_CLASSES:append:rauc-ab-bootrootfs = " boot-vfat-image"
+    IMAGE_FSTYPES:append:rauc-ab-bootrootfs = " boot.vfat"
+    WKS_FILE:rauc-ab-bootrootfs = "imx-2boot-res-2rootfs-data.wks.in"
+
+Build your bundle. It will also build your your respective wic image::
+
+    $ bitbake update-bundle
+
+

--- a/meta-rauc-nxp/README.rst
+++ b/meta-rauc-nxp/README.rst
@@ -39,7 +39,7 @@ Actual requirements may differ from project to project and will
 probably need a much different RAUC/bootloader/system configuration.
 
 
-Currently this layer supports only cubox-i/HummingBoard boards.
+Currently this layer supports cubox-i/HummingBoard boards, and the FRDM-IMX93 development board.
 
 
 I. Adding the meta-rauc-nxp layer to your build
@@ -51,7 +51,7 @@ Run 'bitbake-layers add-layer meta-rauc-nxp'
 II. Build NXP Demo System
 ===============================================
 
-For Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND set in local.conf:
+For Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND set in local.conf::
 
     MACHINE = "olimex-imx8mp-evb"
     INIT_MANAGER = "systemd"
@@ -60,6 +60,10 @@ For Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND set in local.conf:
     DISTRO_FEATURES:append = " rauc"
     IMAGE_FSTYPES:append = " ext4"
     IMAGE_BOOT_FILES:append = " boot.scr"
+
+For FRDM-IMX93 you would can use the exact same parameters as above (i.e., use the ``dual-imx-boot-bootpart.wks.in`` kickstart file), and use the following ``MACHINE``::
+
+    MACHINE = "imx93frdm"
 
 For cubox-i/HummingBoard follow the steps below:
 
@@ -157,3 +161,4 @@ A convenient way to host HTTP server is::
 
 After the update is complete reboot the board to boot from the updated rootfs.
 
+The steps for the iMX93 boards are identical, other than the file names. For example, should you build ``core-image-base`` (which is the default bundled image in all of the aforementioned products in this README fie), your will want to install ``update-bundle-imx93frdm.raucb`` and flash the corresponding ``.wic.zstd`` image name respectfully.

--- a/meta-rauc-nxp/README.rst
+++ b/meta-rauc-nxp/README.rst
@@ -61,7 +61,7 @@ For Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND set in local.conf::
     IMAGE_FSTYPES:append = " ext4"
     IMAGE_BOOT_FILES:append = " boot.scr"
 
-For FRDM-IMX93 you would can use the exact same parameters as above (i.e., use the ``dual-imx-boot-bootpart.wks.in`` kickstart file), and use the following ``MACHINE``::
+For FRDM-IMX93 you can use the exact same parameters as above (i.e., use the ``dual-imx-boot-bootpart.wks.in`` kickstart file), and use the following ``MACHINE``::
 
     MACHINE = "imx93frdm"
 

--- a/meta-rauc-nxp/classes/boot-vfat-image.bbclass
+++ b/meta-rauc-nxp/classes/boot-vfat-image.bbclass
@@ -1,0 +1,46 @@
+do_image_boot_vfat[depends] += "mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"
+do_image_boot_vfat[vardepsexclude] += "DATETIME"
+
+IMAGE_CMD:boot.vfat () {
+        # datetime: compute here to avoid non determinism at the recipe level
+        local datetime=$(date +%Y%m%d%H%M%S)
+        local outfile=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}-${datetime}.boot.vfat
+        local linkfile=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.boot.vfat
+
+        # Remove old timestamped files
+        rm -f ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}-*.boot.vfat
+
+        dd if=/dev/zero of=$outfile bs=1M count=64
+        mkfs.vfat $outfile
+
+        for entry in ${IMAGE_BOOT_FILES}; do
+            src=$(echo $entry | cut -d';' -f1)
+            dst=$(echo $entry | cut -d';' -f2)
+            dst=${dst:-$src}
+            if [ -f ${DEPLOY_DIR_IMAGE}/$src ]; then
+                mcopy -i $outfile -s ${DEPLOY_DIR_IMAGE}/$src ::/$dst
+            else
+                bbwarn "$src does not exist although it is specified in your IMAGE_BOOT_FILES variable"
+            fi
+        done
+
+        cd ${IMGDEPLOYDIR}
+        ln -sf ${IMAGE_BASENAME}-${MACHINE}-${datetime}.boot.vfat $linkfile
+}
+
+#
+# Testing tip:
+# Allow an (optional!) rfile.txt entry at IMGDEPLOYDIR - one can modify it prior to the build, to see a change in a single file, on the boot partition, and it should be super quick
+# e.g., cf. modifying a possibly huge rootfs
+# Then, for testing one could do something like
+# date > tmp/deploy/images/imx93frdm/bootpart.testinfo && bitbake update-bundle
+# Then, because it is an intentional "hack" (to build fast / and not change anything if we don't do it explicitly) one would do, to force a rebuild of the wic (unnecessary, but to to sync the states)
+# and the filesystem, and therefore the bundle as follows:
+#
+# bitbake core-image-minimal -C image_boot_vfat
+# bitbake core-image-minimal
+#
+# If you are interested in doing these tests, uncomment the next line, and then you could mount the boot partition upon boot, and see the works when you will have flashed the image or update bundle
+#
+# IMAGE_BOOT_FILES:append = " bootpart.testinfo"
+#

--- a/meta-rauc-nxp/recipes-bsp/u-boot/u-boot-imx/rauc-ab-bootrootfs/boot.cmd
+++ b/meta-rauc-nxp/recipes-bsp/u-boot/u-boot-imx/rauc-ab-bootrootfs/boot.cmd
@@ -1,0 +1,80 @@
+test -n "${BOOT_ORDER}" || env set BOOT_ORDER "A B"
+test -n "${BOOT_A_LEFT}" || env set BOOT_A_LEFT 3
+test -n "${BOOT_B_LEFT}" || env set BOOT_B_LEFT 3
+
+env set boot_pno
+env set rootfs_pno;
+env set rauc_slot
+
+echo "[+] Booting from mmc device: $mmcdev"
+
+for BOOT_SLOT in "${BOOT_ORDER}"; do
+    if test "x${rootfs_pno}" != "x"; then
+        # stop checking after selecting a slot
+
+    elif test "x${BOOT_SLOT}" = "xA"; then
+        if itest ${BOOT_A_LEFT} -gt 0; then
+            setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
+            echo "Booting RAUC slot A"
+
+            setenv rootfs_pno 5
+            setenv boot_pno 1
+            setenv rauc_slot "A"
+        fi
+
+    elif test "x${BOOT_SLOT}" = "xB"; then
+        if itest ${BOOT_B_LEFT} -gt 0; then
+            setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
+            echo "Booting RAUC slot B"
+
+            setenv rootfs_pno 6
+            setenv boot_pno 2
+            setenv rauc_slot "B"
+        fi
+    fi
+done
+
+
+if test -n "${rootfs_pno}"; then
+    setenv mmcpart $boot_pno;
+    saveenv
+else
+    echo "No valid RAUC slot found. Resetting attempts to 3"
+    setenv BOOT_A_LEFT 3
+    setenv BOOT_B_LEFT 3
+    saveenv
+    reset
+fi
+
+if itest $mmcdev -eq 1 ; then
+    echo "[+] Will now boot RAUC slot $rauc_slot from sdcard"
+elif itest $mmcdev -eq 0 ; then 
+    echo "[+] Will now boot RAUC slot $rauc_slot from eMMC"
+else
+    echo "***ERROR: Will ignore mmc device $mmcdev"
+    reset
+fi
+
+if mmc dev $mmcdev; then
+    run sr_ir_v2_cmd
+    mmc dev $mmcdev
+    setenv devtype mmc
+    setenv devnum $mmcdev
+    setenv distro_bootpart $boot_pno
+    run scan_dev_for_efi
+    setenv mmcroot /dev/mmcblk${mmcdev}p${rootfs_pno} rootwait rw rauc.slot=${rauc_slot} rauc_example_mode=rauc-ab-bootrootfs
+    if fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr_r} ${fdtfile} ; then
+        if fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image} ; then
+            setenv bootargs ${jh_clk} ${mcore_clk} console=${console} root=${mmcroot}
+            booti ${loadaddr} - ${fdt_addr_r}
+	else
+	    echo "***ERROR: Failed to boot the Linux kernel"
+	fi
+    else
+	echo "***ERROR: Failed to load the device tree blob $fdtfile"
+    fi
+else
+    echo "***Could not find mmc device $mmcdev"
+    reset
+fi
+

--- a/meta-rauc-nxp/recipes-core/base-files/files/rauc-ab-bootrootfs/fstab
+++ b/meta-rauc-nxp/recipes-core/base-files/files/rauc-ab-bootrootfs/fstab
@@ -1,0 +1,6 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+
+/dev/mmcblk1p7 /data   ext4    defaults        0       0

--- a/meta-rauc-nxp/recipes-core/bundles/update-bundle.bb
+++ b/meta-rauc-nxp/recipes-core/bundles/update-bundle.bb
@@ -2,15 +2,45 @@ DESCRIPTION = "RAUC bundle generator"
 
 inherit bundle
 
+# Allow selection of the bundle rather than hardcoding it
+BUNDLE_IMAGE_NAME ?= "core-image-base"
+
 RAUC_BUNDLE_FORMAT = "verity"
 
 RAUC_BUNDLE_COMPATIBLE = "${MACHINE}"
-RAUC_BUNDLE_VERSION = "v20240627"
+RAUC_BUNDLE_VERSION = "v20260328"
 RAUC_BUNDLE_DESCRIPTION = "RAUC demonstration bundle"
 
 RAUC_BUNDLE_SLOTS = "rootfs"
-RAUC_SLOT_rootfs = "core-image-base"
+RAUC_SLOT_rootfs = "${BUNDLE_IMAGE_NAME}"
 RAUC_SLOT_rootfs[fstype] = "ext4"
 
 RAUC_KEY_FILE ?= "${THISDIR}/files/development-1.key.pem"
 RAUC_CERT_FILE ?= "${THISDIR}/files/development-1.cert.pem"
+
+#---------------------------------------------------
+# Everything here and below is a conditional support
+# for having dual boot partition as well.
+#---------------------------------------------------
+RAUC_BUNDLE_SLOTS:append:rauc-ab-bootrootfs = " boot"
+RAUC_SLOT_boot:rauc-ab-bootrootfs = "${BUNDLE_IMAGE_NAME}"
+
+#
+# Dynamic file naming based on the overrides
+# The only reason for this function is to keep the previous behavior working for the other iMX products. It would be much more elegant to have another layer.
+# It is not possible to both use the dictionary and an override together (e.g. as in RAUC_SLOT_boot:... and RAUC_BUNDLE_SLOTS:... above.
+#
+python () {
+    # Do something like
+    #  RAUC_SLOT_boot:rauc-ab-bootrootfs[fstype] = "boot.vfat"
+    #  RAUC_SLOT_boot:rauc-ab-bootrootfs[file] = "${BUNDLE_IMAGE_NAME}-${MACHINE}.boot.vfat"
+    # But legally
+    overrides = d.getVar('OVERRIDES').split(':')
+    if 'rauc-ab-bootrootfs' not in overrides:
+        return
+
+    machine = d.getVar('MACHINE')
+    img     = d.getVar('BUNDLE_IMAGE_NAME')
+    d.setVarFlag('RAUC_SLOT_boot', 'fstype', 'boot.vfat')
+    d.setVarFlag('RAUC_SLOT_boot', 'file',   f'{img}-{machine}.boot.vfat')
+}

--- a/meta-rauc-nxp/recipes-core/rauc/files/rauc-ab-bootrootfs/system.conf
+++ b/meta-rauc-nxp/recipes-core/rauc/files/rauc-ab-bootrootfs/system.conf
@@ -1,0 +1,40 @@
+##################################################################################
+# RAUC system conf compatible with the community partition layout 
+# and with the community writing to sdcard.
+# To write to the eMMC, e.g. in FRDM-IMX93, use mmcblk0.
+# TODO: if anyone cares, add a @@MMCDEVICE@@ literal and sed it like the MACHINE
+#       I might do it after proving "backward compatibility" to the current meta-rauc-community project
+##################################################################################
+[system]
+compatible=@@MACHINE@@
+bootloader=uboot
+data-directory=/data/
+
+[keyring]
+path=/etc/rauc/ca.cert.pem
+
+# ----------------------------------------------------------------------
+# SLOT A
+# ----------------------------------------------------------------------
+[slot.rootfs.0]
+device=/dev/mmcblk1p5
+type=ext4
+bootname=A
+
+[slot.boot.0]
+device=/dev/mmcblk1p1
+type=vfat
+parent=rootfs.0
+
+# ----------------------------------------------------------------------
+# SLOT B
+# ----------------------------------------------------------------------
+[slot.rootfs.1]
+device=/dev/mmcblk1p6
+type=ext4
+bootname=B
+
+[slot.boot.1]
+device=/dev/mmcblk1p2
+type=vfat
+parent=rootfs.1

--- a/meta-rauc-nxp/recipes-core/rauc/rauc-grow-partition.inc
+++ b/meta-rauc-nxp/recipes-core/rauc/rauc-grow-partition.inc
@@ -1,0 +1,26 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append := "  \
+	file://rauc-grow-data-partition.service \
+	file://grow-data-partition.sh \
+"
+
+RDEPENDS:${PN} += "u-boot-fw-utils u-boot-imx-env"
+DEPENDS += "u-boot"
+
+inherit systemd
+
+SYSTEMD_PACKAGES += "${PN}-grow-data-part"
+SYSTEMD_SERVICE:${PN}-grow-data-part = "rauc-grow-data-partition.service"
+
+PACKAGES += "rauc-grow-data-part"
+
+RDEPENDS:${PN}-grow-data-part += "parted e2fsprogs-resize2fs gptfdisk"
+
+do_install:append() {
+	install -d ${D}${systemd_unitdir}/system/
+	install -m 0644 ${WORKDIR}/rauc-grow-data-partition.service ${D}${systemd_unitdir}/system/
+
+	install -d ${D}/${bindir}
+	install -m 0755 ${WORKDIR}/grow-data-partition.sh ${D}/${bindir}
+}

--- a/meta-rauc-nxp/recipes-core/rauc/rauc_%.bbappend
+++ b/meta-rauc-nxp/recipes-core/rauc/rauc_%.bbappend
@@ -1,26 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI:append := "  \
-	file://rauc-grow-data-partition.service \
-	file://grow-data-partition.sh \
-"
-
-RDEPENDS:${PN} += "u-boot-fw-utils u-boot-imx-env"
-DEPENDS += "u-boot"
-
-inherit systemd
-
-SYSTEMD_PACKAGES += "${PN}-grow-data-part"
-SYSTEMD_SERVICE:${PN}-grow-data-part = "rauc-grow-data-partition.service"
-
-PACKAGES += "rauc-grow-data-part"
-
-RDEPENDS:${PN}-grow-data-part += "parted e2fsprogs-resize2fs gptfdisk"
-
-do_install:append() {
-	install -d ${D}${systemd_unitdir}/system/
-	install -m 0644 ${WORKDIR}/rauc-grow-data-partition.service ${D}${systemd_unitdir}/system/
-
-	install -d ${D}/${bindir}
-	install -m 0755 ${WORKDIR}/grow-data-partition.sh ${D}/${bindir}
-}
+# For backward compatability, only include the grow-partition logic if 'rauc-ab-bootrootfs' is NOT in OVERRIDES
+# The .inc file is identical to the previous contents of this .bbappend file
+include ${@bb.utils.contains('OVERRIDES', 'rauc-ab-bootrootfs', '', 'rauc-grow-partition.inc', d)}

--- a/meta-rauc-nxp/recipes-core/udev/files/rauc-ab-bootrootfs.rules
+++ b/meta-rauc-nxp/recipes-core/udev/files/rauc-ab-bootrootfs.rules
@@ -1,0 +1,10 @@
+/dev/mmcblk0p1
+/dev/mmcblk0p2
+/dev/mmcblk0p3
+/dev/mmcblk0p5
+/dev/mmcblk0p6
+/dev/mmcblk1p1
+/dev/mmcblk1p2
+/dev/mmcblk1p3
+/dev/mmcblk1p5
+/dev/mmcblk1p6

--- a/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
+++ b/meta-rauc-nxp/recipes-core/udev/udev-extraconf_%.bbappend
@@ -4,3 +4,12 @@ SRC_URI:append:cubox-i = " file://cubox-i-rauc.rules"
 do_install:append:cubox-i() {
     install -m 0644 ${WORKDIR}/cubox-i-rauc.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
 }
+
+
+FILESEXTRAPATHS:prepend:rauc-ab-bootrootfs := "${THISDIR}/files:"
+SRC_URI:append:rauc-ab-bootrootfs = " file://rauc-ab-bootrootfs.rules"
+
+do_install:append:rauc-ab-bootrootfs() {
+    install -m 0644 ${WORKDIR}/rauc-ab-bootrootfs.rules ${D}${sysconfdir}/udev/mount.ignorelist.d/
+}
+

--- a/meta-rauc-nxp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/meta-rauc-nxp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += "file://rauc.cfg"
+
+# linux-imx from meta-imx/meta-imx-bsp does not inherit linux-yocto and does not implement the fragment mechanisms.
+# So we just add it and call merge-config manually, should one choose to use the iMX downstream recipe (rather than the community fsl one)
+do_configure:append() {
+	# ${S}: source ;  ${B}: build ; ${WORKDIR}: workdir (fragments go there via SRC_URI)
+	if [ -f "${WORKDIR}/rauc.cfg" ]; then
+		# We use the kernel's own script to ensure it's done right
+		${S}/scripts/kconfig/merge_config.sh -m -O ${B} ${B}/.config ${WORKDIR}/rauc.cfg
+
+		# This part ensures the .config is valid and dependencies are resolved
+		oe_runmake -C ${S} O=${B} oldconfig
+	fi
+}

--- a/meta-rauc-nxp/wic/imx-2boot-res-2rootfs-data.wks.in
+++ b/meta-rauc-nxp/wic/imx-2boot-res-2rootfs-data.wks.in
@@ -1,0 +1,21 @@
+#
+# This kickstart file:
+# - Puts imx-boot in the right place
+# - Defines two vfat filesystems (p1,p2)
+# - Defines a placeholder for a rescue/recovery partition (p3)
+# - Defines two ext4 filesystems (p5,p6)
+#
+# GPT tables could be used interchangably
+# The names after the "part" statement are not really needed, unless one wants to do some more scripting.
+#
+part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
+
+part /boot --source bootimg-partition --ondisk mmcblk --fstype=vfat --label BOOT_A --active --align 8192 --size ${BOOT_PARTITION_SIZE_MIB}
+part /boot_b --source bootimg-partition --ondisk mmcblk --fstype=vfat --label BOOT_B --align 8192 --size ${BOOT_PARTITION_SIZE_MIB}
+# Add a hole to have the system partitions logical. This is a good place to add a recovery/rescue image if you want
+part /res --ondisk mmcblk --label RES --fixed-size ${RES_PARTITION_SIZE_MIB}
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label ROOTFS_A --align 8192
+part /rootfs_b --source rootfs --ondisk mmcblk --fstype=ext4 --label ROOTFS_B --align 8192
+part /data --ondisk mmcblk --fstype=ext4 --label DATA --align 8192 --fixed-size ${DATA_PARTITION_SIZE_MIB}
+
+bootloader --ptable msdos


### PR DESCRIPTION
Since the board layout is very similar to one of the products, the layer included, the changes here are very minimalistics:
- Updated the README file
- Added a recipe for building out of meta-imx which does no build off linux-yocto